### PR TITLE
在job中添加public  void afterAllShardingComplete()方法，处理所有分片都执行完毕后需要处理的后续动作，

### DIFF
--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
@@ -259,6 +259,23 @@ public final class ExecutionService {
         return jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(item));
     }
     
+    /**
+     * 判断是否所有分片都执行完毕
+     * @return  是否所有分片都执行完毕
+     */
+    public boolean isAllCompleted() {
+    	boolean returnFlag = true;
+    	List<Integer> list =  getAllItems() ;
+    	for(int index=0;index<list.size();index++){
+    		if(!jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(list.get(index)))){
+    			returnFlag = false;
+    			break;
+    		}
+    	}
+    	
+        return returnFlag;
+    }
+    
     private List<Integer> getAllItems() {
         return Lists.transform(jobNodeStorage.getJobNodeChildrenKeys(ExecutionNode.ROOT), new Function<String, Integer>() {
             

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
@@ -88,6 +88,10 @@ public abstract class AbstractElasticJob implements ElasticJob {
         if (configService.isFailover() && !stoped) {
             failoverService.failoverIfNecessary();
         }
+        if(executionService.isAllCompleted()){
+        	afterAllShardingComplete();
+        	log.debug("Elastic job: all sharding completed.");
+        }
         log.debug("Elastic job: execute all completed, job execution context:{}.", context);
     }
     
@@ -105,6 +109,13 @@ public abstract class AbstractElasticJob implements ElasticJob {
     }
     
     protected abstract void executeJob(final JobExecutionMultipleShardingContext shardingContext);
+    
+    /**
+     * 处理所有分片都执行完后的动作
+     */
+    public  void afterAllShardingComplete(){
+    	//默认什么不都执行
+    }
     
     /**
      * 停止运行中的作业.


### PR DESCRIPTION
在job中添加public  void afterAllShardingComplete()方法，处理所有分片都执行完毕后需要处理的后续动作，
注意： 只针对监控作业状态的job有效，建议只是simple 类型的job使用。