### PR TITLE
添加一次job执行时，所有分片执行完毕后处理收尾工作的方法，

### DIFF
--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/DataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/DataFlowElasticJob.java
@@ -65,4 +65,9 @@ public interface DataFlowElasticJob<T, C extends AbstractJobExecutionShardingCon
      * @param offset 数据处理位置
      */
     void updateOffset(final int item, final String offset);
+    
+    /**
+     * 在非steaming类型的job每次所有的分片都成功执行完后，执行此操作 
+     */
+    void afterAllUnStreamingShardingFinished();
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/DataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/DataFlowElasticJob.java
@@ -67,7 +67,7 @@ public interface DataFlowElasticJob<T, C extends AbstractJobExecutionShardingCon
     void updateOffset(final int item, final String offset);
     
     /**
-     * 在非steaming类型的job每次所有的分片都成功执行完后，执行此操作 
+     * 在非steaming类型的job每次所有的分片都成功执行完后，执行此操作.
      */
     void afterAllUnStreamingShardingFinished();
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
@@ -8,7 +8,7 @@ package com.dangdang.ddframe.job.api;
 public interface SimpleElasticJob extends ElasticJob {
 
 	/**
-	 * 所有分片都执行完毕后，处理收尾任务
+	 * 所有分片都执行完毕后，处理收尾任务.
 	 */
     public void afterAllShardingFinished();
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
@@ -10,5 +10,5 @@ public interface SimpleElasticJob extends ElasticJob {
 	/**
 	 * 所有分片都执行完毕后，处理收尾任务
 	 */
-    public  void afterAllShardingFinished();
+    public void afterAllShardingFinished();
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/api/SimpleElasticJob.java
@@ -1,0 +1,14 @@
+package com.dangdang.ddframe.job.api;
+
+/**
+ * simple 类型的任务接口.
+ * 
+ * @author zhong
+ */
+public interface SimpleElasticJob extends ElasticJob {
+
+	/**
+	 * 所有分片都执行完毕后，处理收尾任务
+	 */
+    public  void afterAllShardingFinished();
+}

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
@@ -259,6 +259,23 @@ public final class ExecutionService {
         return jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(item));
     }
     
+    /**
+     * 判断是否所有分片都执行完毕
+     * @return  是否所有分片都执行完毕
+     */
+    public boolean isAllCompleted() {
+    	boolean returnFlag = true;
+    	List<Integer> list =  getAllItems() ;
+    	for(int index=0;index<list.size();index++){
+    		if(!jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(list.get(index)))){
+    			returnFlag = false;
+    			break;
+    		}
+    	}
+    	
+        return returnFlag;
+    }
+    
     private List<Integer> getAllItems() {
         return Lists.transform(jobNodeStorage.getJobNodeChildrenKeys(ExecutionNode.ROOT), new Function<String, Integer>() {
             

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/execution/ExecutionService.java
@@ -260,20 +260,21 @@ public final class ExecutionService {
     }
     
     /**
-     * 判断是否所有分片都执行完毕
+     * 判断是否所有分片都执行完毕.
      * @return  是否所有分片都执行完毕
      */
     public boolean isAllCompleted() {
-    	boolean returnFlag = true;
-    	List<Integer> list =  getAllItems() ;
-    	for(int index=0;index<list.size();index++){
-    		if(!jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(list.get(index)))){
-    			returnFlag = false;
+    	boolean result = true;
+    	List<Integer> list =  getAllItems();
+    	
+    	for(Integer item : list){
+    		if(!jobNodeStorage.isJobNodeExisted(ExecutionNode.getCompletedNode(item))){
+    			result = false;
     			break;
     		}
     	}
     	
-        return returnFlag;
+        return result;
     }
     
     private List<Integer> getAllItems() {

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
@@ -89,7 +89,7 @@ public abstract class AbstractElasticJob implements ElasticJob {
             failoverService.failoverIfNecessary();
         }
         if(executionService.isAllCompleted()){
-        	afterAllShardingComplete();
+        	afterAllShardingFinishedInternal();
         	log.debug("Elastic job: all sharding completed.");
         }
         log.debug("Elastic job: execute all completed, job execution context:{}.", context);
@@ -111,11 +111,9 @@ public abstract class AbstractElasticJob implements ElasticJob {
     protected abstract void executeJob(final JobExecutionMultipleShardingContext shardingContext);
     
     /**
-     * 处理所有分片都执行完后的动作
+     * 所有分片都成功执行完后，执行此方法
      */
-    public  void afterAllShardingComplete(){
-    	//默认什么不都执行
-    }
+    protected abstract  void afterAllShardingFinishedInternal();
     
     /**
      * 停止运行中的作业.

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
@@ -111,9 +111,9 @@ public abstract class AbstractElasticJob implements ElasticJob {
     protected abstract void executeJob(final JobExecutionMultipleShardingContext shardingContext);
     
     /**
-     * 所有分片都成功执行完后，执行此方法
+     * 所有分片都成功执行完后，执行此方法.
      */
-    protected abstract  void afterAllShardingFinishedInternal();
+    protected abstract void afterAllShardingFinishedInternal();
     
     /**
      * 停止运行中的作业.

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/job/AbstractElasticJob.java
@@ -88,6 +88,10 @@ public abstract class AbstractElasticJob implements ElasticJob {
         if (configService.isFailover() && !stoped) {
             failoverService.failoverIfNecessary();
         }
+        if(executionService.isAllCompleted()){
+        	afterAllShardingComplete();
+        	log.debug("Elastic job: all sharding completed.");
+        }
         log.debug("Elastic job: execute all completed, job execution context:{}.", context);
     }
     
@@ -105,6 +109,13 @@ public abstract class AbstractElasticJob implements ElasticJob {
     }
     
     protected abstract void executeJob(final JobExecutionMultipleShardingContext shardingContext);
+    
+    /**
+     * 处理所有分片都执行完后的动作
+     */
+    public  void afterAllShardingComplete(){
+    	//默认什么不都执行
+    }
     
     /**
      * 停止运行中的作业.

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
@@ -60,8 +60,8 @@ public abstract class AbstractSequenceDataFlowElasticJob<T> extends AbstractData
     }
     
     @Override
-	public void afterAllUnStreamingShardingFinished() {
-	}
+    public void afterAllUnStreamingShardingFinished() {
+    }
     
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {
         Map<Integer, List<T>> data = concurrentFetchData(shardingContext);

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
@@ -52,6 +52,18 @@ public abstract class AbstractSequenceDataFlowElasticJob<T> extends AbstractData
         }
     }
     
+    @Override
+    protected  void afterAllShardingFinishedInternal(){
+    	if (!isStreamingProcess()) {
+    		afterAllUnStreamingShardingFinished();
+        }
+    }
+    
+    @Override
+	public void afterAllUnStreamingShardingFinished() {
+		
+	}
+    
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {
         Map<Integer, List<T>> data = concurrentFetchData(shardingContext);
         while (!data.isEmpty() && !isStoped() && !getShardingService().isNeedSharding()) {

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
@@ -54,8 +54,8 @@ public abstract class AbstractSequenceDataFlowElasticJob<T> extends AbstractData
     
     @Override
     protected  void afterAllShardingFinishedInternal(){
-    	if (!isStreamingProcess()) {
-    		afterAllUnStreamingShardingFinished();
+        if (!isStreamingProcess()) {
+            afterAllUnStreamingShardingFinished();
         }
     }
     

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSequenceDataFlowElasticJob.java
@@ -61,7 +61,6 @@ public abstract class AbstractSequenceDataFlowElasticJob<T> extends AbstractData
     
     @Override
 	public void afterAllUnStreamingShardingFinished() {
-		
 	}
     
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
@@ -20,6 +20,7 @@ package com.dangdang.ddframe.job.plugin.job.type;
 import lombok.extern.slf4j.Slf4j;
 
 import com.dangdang.ddframe.job.api.JobExecutionMultipleShardingContext;
+import com.dangdang.ddframe.job.api.SimpleElasticJob;
 import com.dangdang.ddframe.job.internal.job.AbstractElasticJob;
 
 /**
@@ -32,7 +33,7 @@ import com.dangdang.ddframe.job.internal.job.AbstractElasticJob;
  * @author zhangliang, caohao
  */
 @Slf4j
-public abstract class AbstractSimpleElasticJob extends AbstractElasticJob {
+public abstract class AbstractSimpleElasticJob extends AbstractElasticJob implements SimpleElasticJob {
     
     @Override
     protected final void executeJob(final JobExecutionMultipleShardingContext shardingContext) {
@@ -57,7 +58,7 @@ public abstract class AbstractSimpleElasticJob extends AbstractElasticJob {
      */
     public abstract void process(final JobExecutionMultipleShardingContext shardingContext);
     
-    
+    @Override
     public  void afterAllShardingFinished(){
     	
     }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
@@ -60,6 +60,5 @@ public abstract class AbstractSimpleElasticJob extends AbstractElasticJob implem
     
     @Override
     public  void afterAllShardingFinished(){
-    	
     }
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractSimpleElasticJob.java
@@ -45,10 +45,20 @@ public abstract class AbstractSimpleElasticJob extends AbstractElasticJob {
         }
     }
     
+    @Override
+    protected  void afterAllShardingFinishedInternal(){
+    	afterAllShardingFinished();
+    }
+    
     /**
      * 执行作业.
      * 
      * @param shardingContext 作业分片规则配置上下文
      */
     public abstract void process(final JobExecutionMultipleShardingContext shardingContext);
+    
+    
+    public  void afterAllShardingFinished(){
+    	
+    }
 }

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
@@ -49,6 +49,18 @@ public abstract class AbstractThroughputDataFlowElasticJob<T> extends AbstractDa
         }
     }
     
+    @Override
+    protected  void afterAllShardingFinishedInternal(){
+    	if (!isStreamingProcess()) {
+    		afterAllUnStreamingShardingFinished();
+        }
+    }
+
+    @Override
+	public void afterAllUnStreamingShardingFinished() {
+		
+	}
+    
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {
         List<T> data = fetchDataWithLog(shardingContext);
         while (null != data && !data.isEmpty() && !isStoped() && !getShardingService().isNeedSharding()) {

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
@@ -58,7 +58,6 @@ public abstract class AbstractThroughputDataFlowElasticJob<T> extends AbstractDa
 
     @Override
 	public void afterAllUnStreamingShardingFinished() {
-		
 	}
     
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {

--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/plugin/job/type/AbstractThroughputDataFlowElasticJob.java
@@ -52,13 +52,13 @@ public abstract class AbstractThroughputDataFlowElasticJob<T> extends AbstractDa
     @Override
     protected  void afterAllShardingFinishedInternal(){
     	if (!isStreamingProcess()) {
-    		afterAllUnStreamingShardingFinished();
+            afterAllUnStreamingShardingFinished();
         }
     }
 
     @Override
-	public void afterAllUnStreamingShardingFinished() {
-	}
+    public void afterAllUnStreamingShardingFinished() {
+    }
     
     private void executeStreamingJob(final JobExecutionMultipleShardingContext shardingContext) {
         List<T> data = fetchDataWithLog(shardingContext);

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractBaseJobTest {
         }
 
 		@Override
-		protected void afterAllShardingFinishedInternal() {
-		}
+        protected void afterAllShardingFinishedInternal() {
+	    }
     }
 }

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
@@ -69,5 +69,11 @@ public abstract class AbstractBaseJobTest {
         @Override
         protected void executeJob(final JobExecutionMultipleShardingContext jobExecutionShardingContext) {
         }
+
+		@Override
+		protected void afterAllShardingFinishedInternal() {
+			// TODO Auto-generated method stub
+			
+		}
     }
 }

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
@@ -72,8 +72,6 @@ public abstract class AbstractBaseJobTest {
 
 		@Override
 		protected void afterAllShardingFinishedInternal() {
-			// TODO Auto-generated method stub
-			
 		}
     }
 }

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/AbstractBaseJobTest.java
@@ -70,8 +70,8 @@ public abstract class AbstractBaseJobTest {
         protected void executeJob(final JobExecutionMultipleShardingContext jobExecutionShardingContext) {
         }
 
-		@Override
+        @Override
         protected void afterAllShardingFinishedInternal() {
-	    }
+        }
     }
 }

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
@@ -253,9 +253,9 @@ public final class ConfigurationServiceTest extends AbstractBaseJobTest {
         protected void executeJob(final JobExecutionMultipleShardingContext jobExecutionShardingContext) {
         }
 
-		@Override
-		protected void afterAllShardingFinishedInternal() {
-		}
+        @Override
+        protected void afterAllShardingFinishedInternal() {
+        }
     }
     
     @Getter

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
@@ -252,6 +252,12 @@ public final class ConfigurationServiceTest extends AbstractBaseJobTest {
         @Override
         protected void executeJob(final JobExecutionMultipleShardingContext jobExecutionShardingContext) {
         }
+
+		@Override
+		protected void afterAllShardingFinishedInternal() {
+			// TODO Auto-generated method stub
+			
+		}
     }
     
     @Getter

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/config/ConfigurationServiceTest.java
@@ -255,8 +255,6 @@ public final class ConfigurationServiceTest extends AbstractBaseJobTest {
 
 		@Override
 		protected void afterAllShardingFinishedInternal() {
-			// TODO Auto-generated method stub
-			
 		}
     }
     


### PR DESCRIPTION
针对 simple job，添加 afterAllShardingFinished（）方法，默认实现不做任何事情，
针对dataFLow类型的unstreaming
job，添加afterAllUnSteamingShardingFinished(),只有非流式job该方法才有效