### PR TITLE
Add disable/enable buttons to Console

### DIFF
--- a/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/controller/JobOperationController.java
+++ b/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/controller/JobOperationController.java
@@ -72,4 +72,14 @@ public class JobOperationController {
     public void removeJob(final JobServer jobServer) {
         jobOperationService.removeJob(jobServer.getJobName(), jobServer.getIp());
     }
+
+    @RequestMapping(value = "disable", method = RequestMethod.POST)
+    public void disableJob(final JobServer jobServer) {
+        jobOperationService.disableJob(jobServer.getJobName(), jobServer.getIp());
+    }
+
+    @RequestMapping(value = "enable", method = RequestMethod.POST)
+    public void enableJob(final JobServer jobServer) {
+        jobOperationService.enableJob(jobServer.getJobName(), jobServer.getIp());
+    }
 }

--- a/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/service/JobOperationService.java
+++ b/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/service/JobOperationService.java
@@ -34,4 +34,8 @@ public interface JobOperationService {
     void shutdownJob(String jobName, String serverIp);
     
     boolean removeJob(String jobName, String serverIp);
+
+    void disableJob(String jobName, String serverIp);
+
+    void enableJob(String jobName, String serverIp);
 }

--- a/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/service/impl/JobOperationServiceImpl.java
+++ b/elastic-job-console/src/main/java/com/dangdang/ddframe/job/console/service/impl/JobOperationServiceImpl.java
@@ -93,4 +93,14 @@ public class JobOperationServiceImpl implements JobOperationService {
         }
         return false;
     }
+
+    @Override
+    public void disableJob(final String jobName, final String serverIp) {
+        curatorRepository.create(JobNodePath.getServerNodePath(jobName, serverIp, "disabled"));
+    }
+
+    @Override
+    public void enableJob(final String jobName, final String serverIp) {
+        curatorRepository.delete(JobNodePath.getServerNodePath(jobName, serverIp, "disabled"));
+    }
 }

--- a/elastic-job-console/src/main/webapp/js/job_detail.js
+++ b/elastic-job-console/src/main/webapp/js/job_detail.js
@@ -16,6 +16,8 @@ $(function() {
     bindResumeAllButton();
     bindShutdownButtons();
     bindRemoveButtons();
+    bindDisableButtons();
+    bindEnableButtons();
 });
 
 function renderSettings() {
@@ -87,6 +89,8 @@ function renderServers() {
             var stopButton = "<button operation='stop' class='btn btn-warning' ip='" + data[i].ip + "'" + (leader ? "data-toggle='modal' data-target='#stop-leader-confirm-dialog'" : "") + ">暂停</button>";
             var shutdownButton = "<button operation='shutdown' class='btn btn-danger' ip='" + data[i].ip + "'>关闭</button>";
             var removeButton = "<button operation='remove' class='btn btn-danger' ip='" + data[i].ip + "'>删除</button>";
+            var disableButton = "<button operation='disable' class='btn btn-danger' ip='" + data[i].ip + "'>失效</button>";
+            var enableButton = "<button operation='enable' class='btn btn-success' ip='" + data[i].ip + "'>生效</button>";
             if ("STOPED" === status) {
                 operationTd = resumeButton + "&nbsp;";
             } else if ("DISABLED" !== status && "CRASHED" !== status && "SHUTDOWN" !== status) {
@@ -96,7 +100,12 @@ function renderServers() {
                 operationTd = operationTd + shutdownButton + "&nbsp;";
             }
             if ("SHUTDOWN" === status || "CRASHED" === status) {
-                operationTd = operationTd + removeButton;
+                operationTd = operationTd + removeButton + "&nbsp;";
+            }
+            if("DISABLED" == status) {
+                operationTd = operationTd + enableButton;
+            } else if ("CRASHED" !== status && "SHUTDOWN" !== status){
+                operationTd = operationTd + disableButton;
             }
             operationTd = "<td>" + operationTd + "</td>";
             var trClass = "";
@@ -197,6 +206,26 @@ function bindRemoveButtons() {
     $(document).on("click", "button[operation='remove']", function(event) {
         var jobName = $("#job-name").text();
         $.post("job/remove", {jobName : jobName, ip : $(event.currentTarget).attr("ip")}, function (data) {
+            renderServers();
+            showSuccessDialog();
+        });
+    });
+}
+
+function bindDisableButtons() {
+    $(document).on("click", "button[operation='disable']", function(event) {
+        var jobName = $("#job-name").text();
+        $.post("job/disable", {jobName : jobName, ip : $(event.currentTarget).attr("ip")}, function (data) {
+            renderServers();
+            showSuccessDialog();
+        });
+    });
+}
+
+function bindEnableButtons() {
+    $(document).on("click", "button[operation='enable']", function(event) {
+        var jobName = $("#job-name").text();
+        $.post("job/enable", {jobName : jobName, ip : $(event.currentTarget).attr("ip")}, function (data) {
             renderServers();
             showSuccessDialog();
         });


### PR DESCRIPTION
#### 在console上增加了disable/enable按钮。
当前任务参数配置disable为true后，启动后无法修改。
但是实际中，某些服务器在线上需要动态调整执行任务分配。
通过修改，可以通过console直接给某些job增加或减少可执行的server。