### PR TITLE
解决需要分片时，从节点可能优先执行的问题

### DIFF
--- a/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/storage/JobNodeStorage.java
+++ b/elastic-job-core/src/main/java/com/dangdang/ddframe/job/internal/storage/JobNodeStorage.java
@@ -17,11 +17,8 @@
 
 package com.dangdang.ddframe.job.internal.storage;
 
-import com.dangdang.ddframe.job.api.config.JobConfiguration;
-import com.dangdang.ddframe.job.exception.JobException;
-import com.dangdang.ddframe.reg.base.CoordinatorRegistryCenter;
-import com.dangdang.ddframe.reg.exception.RegExceptionHandler;
-import lombok.Getter;
+import java.util.List;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
 import org.apache.curator.framework.recipes.cache.TreeCache;
@@ -29,7 +26,12 @@ import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.curator.framework.state.ConnectionStateListener;
 
-import java.util.List;
+import com.dangdang.ddframe.job.api.config.JobConfiguration;
+import com.dangdang.ddframe.job.exception.JobException;
+import com.dangdang.ddframe.reg.base.CoordinatorRegistryCenter;
+import com.dangdang.ddframe.reg.exception.RegExceptionHandler;
+
+import lombok.Getter;
 
 /**
  * 作业节点数据访问类.
@@ -138,7 +140,19 @@ public class JobNodeStorage {
     public void fillEphemeralJobNode(final String node, final Object value) {
         coordinatorRegistryCenter.persistEphemeral(jobNodePath.getFullPath(node), value.toString());
     }
-    
+
+    /**
+     * 如果节点不存在填充临时节点数据,节点存在不覆盖.
+     *
+     * @param node 作业节点名称
+     * @param value 作业节点数据值
+     */
+    public void fillEphemeralJobNodeIfNotExists(final String node, final Object value) {
+        if(!isJobNodeExisted(node)) {
+            coordinatorRegistryCenter.persistEphemeral(jobNodePath.getFullPath(node), value.toString());
+        }
+    }
+
     /**
      * 更新节点数据.
      * 

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/sharding/ShardingServiceTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/sharding/ShardingServiceTest.java
@@ -28,6 +28,7 @@ import com.dangdang.ddframe.job.internal.server.ServerService;
 import com.dangdang.ddframe.job.internal.storage.JobNodeStorage;
 import com.dangdang.ddframe.job.internal.storage.TransactionExecutionCallback;
 import com.dangdang.ddframe.job.plugin.sharding.strategy.AverageAllocationJobShardingStrategy;
+
 import org.apache.curator.framework.api.transaction.CuratorTransactionBridge;
 import org.apache.curator.framework.api.transaction.CuratorTransactionFinal;
 import org.apache.curator.framework.api.transaction.TransactionCreateBuilder;
@@ -138,7 +139,7 @@ public final class ShardingServiceTest {
         verify(executionService, times(2)).hasRunningItems();
         verify(jobNodeStorage).removeJobNodeIfExisted("servers/ip1/sharding");
         verify(jobNodeStorage).removeJobNodeIfExisted("servers/ip2/sharding");
-        verify(jobNodeStorage).fillEphemeralJobNode("leader/sharding/processing", "");
+        verify(jobNodeStorage).fillEphemeralJobNodeIfNotExists("leader/sharding/processing", "");
         verify(configService).getJobShardingStrategyClass();
         verify(configService).getShardingTotalCount();
         verify(configService).getShardingItemParameters();
@@ -160,7 +161,7 @@ public final class ShardingServiceTest {
         verify(configService).isMonitorExecution();
         verify(jobNodeStorage).removeJobNodeIfExisted("servers/ip1/sharding");
         verify(jobNodeStorage).removeJobNodeIfExisted("servers/ip2/sharding");
-        verify(jobNodeStorage).fillEphemeralJobNode("leader/sharding/processing", "");
+        verify(jobNodeStorage).fillEphemeralJobNodeIfNotExists("leader/sharding/processing", "");
         verify(configService).getJobShardingStrategyClass();
         verify(configService).getShardingTotalCount();
         verify(configService).getShardingItemParameters();

--- a/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/storage/JobNodeStorageTest.java
+++ b/elastic-job-core/src/test/java/com/dangdang/ddframe/job/internal/storage/JobNodeStorageTest.java
@@ -20,9 +20,10 @@ package com.dangdang.ddframe.job.internal.storage;
 import com.dangdang.ddframe.job.api.config.JobConfiguration;
 import com.dangdang.ddframe.job.api.config.JobConfigurationFactory;
 import com.dangdang.ddframe.job.api.config.impl.SimpleJobConfiguration;
-import com.dangdang.ddframe.job.util.JobConfigurationFieldUtil;
 import com.dangdang.ddframe.job.fixture.TestJob;
+import com.dangdang.ddframe.job.util.JobConfigurationFieldUtil;
 import com.dangdang.ddframe.reg.base.CoordinatorRegistryCenter;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 import org.apache.curator.framework.api.transaction.CuratorTransactionBridge;
@@ -172,7 +173,13 @@ public final class JobNodeStorageTest {
         jobNodeStorage.fillEphemeralJobNode("config/cron", "0/1 * * * * ?");
         verify(coordinatorRegistryCenter).persistEphemeral("/testJob/config/cron", "0/1 * * * * ?");
     }
-    
+
+    @Test
+    public void assertFillEphemeralJobNodeIfNotExists() {
+        jobNodeStorage.fillEphemeralJobNodeIfNotExists("config/cron", "0/1 * * * * ?");
+        verify(coordinatorRegistryCenter).persistEphemeral("/testJob/config/cron", "0/1 * * * * ?");
+    }
+
     @Test
     public void assertUpdateJobNode() {
         jobNodeStorage.updateJobNode("config/cron", "0/1 * * * * ?");


### PR DESCRIPTION
当需要分片时，所有的节点都可以写分片处理标识，只有主节点可以删除，即主节点未分片完成时，从节点需要等待分片完成才能执行