### PR TITLE
springboot-demo细节调整

### DIFF
--- a/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-            <version>1.4.2.RELEASE</version>
+            <version>${springboot.version}</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
@@ -54,9 +54,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
-            <version>${commons-dbcp.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <version>${springboot.version}</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-            <version>${springboot.version}</version>
+            <version>1.4.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/java/com/dangdang/ddframe/job/example/config/DataflowJobConfig.java
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/java/com/dangdang/ddframe/job/example/config/DataflowJobConfig.java
@@ -47,8 +47,8 @@ public class DataflowJobConfig {
     }
     
     @Bean(initMethod = "init")
-    public JobScheduler dataflowJobScheduler(final DataflowJob dataflowJob, @Value("${simpleJob.cron}") final String cron, @Value("${simpleJob.shardingTotalCount}") final int shardingTotalCount,
-                                           @Value("${simpleJob.shardingItemParameters}") final String shardingItemParameters) {
+    public JobScheduler dataflowJobScheduler(final DataflowJob dataflowJob, @Value("${dataflowJob.cron}") final String cron, @Value("${dataflowJob.shardingTotalCount}") final int shardingTotalCount,
+                                           @Value("${dataflowJob.shardingItemParameters}") final String shardingItemParameters) {
         return new SpringJobScheduler(dataflowJob, regCenter, getLiteJobConfiguration(dataflowJob.getClass(), cron, shardingTotalCount, shardingItemParameters), jobEventConfiguration);
     }
     

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/java/com/dangdang/ddframe/job/example/config/JobEventConfig.java
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/java/com/dangdang/ddframe/job/example/config/JobEventConfig.java
@@ -19,22 +19,20 @@ package com.dangdang.ddframe.job.example.config;
 
 import com.dangdang.ddframe.job.event.JobEventConfiguration;
 import com.dangdang.ddframe.job.event.rdb.JobEventRdbConfiguration;
-import org.apache.commons.dbcp.BasicDataSource;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.sql.DataSource;
+
 @Configuration
 public class JobEventConfig {
-    
+
+    @Autowired
+    private DataSource dataSource;
+
     @Bean
-    public JobEventConfiguration jobEventConfiguration(@Value("${jobEventConfig.url}") final String url, @Value("${jobEventConfig.driverClassName}") final String driverClassName, 
-                                                       @Value("${jobEventConfig.username}") final String username, @Value("${jobEventConfig.password}") final String password) {
-        BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setUrl(url);
-        dataSource.setDriverClassName(driverClassName);
-        dataSource.setUsername(username);
-        dataSource.setPassword(password);
+    public JobEventConfiguration jobEventConfiguration() {
         return new JobEventRdbConfiguration(dataSource);
     }
 }

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application-dev.yml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:job_event_storage
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+
+

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application-prod.yml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application-prod.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf-8&verifyServerCertificate=false&useSSL=false&requireSSL=false
+    driver-class-name: com.mysql.jdbc.Driver
+    username: test
+    password: test
+    tomcat:
+      max-wait: 10000
+      min-idle: 0
+      initial-size: 25
+      validation-query: SELECT 1
+      test-on-borrow: false
+      test-while-idle: true
+      time-between-eviction-runs-millis: 18800
+      remove-abandoned: true
+      remove-abandoned-timeout: 180
+
+
+

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application.yml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application.yml
@@ -1,12 +1,7 @@
+
 regCenter:
   serverList: localhost:6181
   namespace: elastic-job-lite-springboot
-
-jobEventConfig:
-  url: jdbc:h2:mem:job_event_storage
-  driverClassName: org.h2.Driver
-  username: sa
-  password:
   
 simpleJob:
   cron: 0/5 * * * * ?
@@ -17,3 +12,7 @@ dataflowJob:
   cron: 0/5 * * * * ?
   shardingTotalCount: 3
   shardingItemParameters: 0=Beijing,1=Shanghai,2=Guangzhou
+
+spring:
+  profiles:
+    active: prod

--- a/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application.yml
+++ b/elastic-job-example/elastic-job-example-lite-springboot/src/main/resources/application.yml
@@ -15,4 +15,4 @@ dataflowJob:
 
 spring:
   profiles:
-    active: prod
+    active: dev


### PR DESCRIPTION
1、使用springboot自带的jdbc starter替换了dbcp
2、修改了dataflow注入的key，原来注入的是simplekey
3、在配置文件中增加mysql数据源配置，并区分开发（使用h2）和生产环境
4、jobevent直接使用springboot生成的datasource bean，简化配置