### PR TITLE
elastic-job-lite-spring的reg配置参数max-retries不起作用

### DIFF
--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/reg/parser/ZookeeperBeanDefinitionParser.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/reg/parser/ZookeeperBeanDefinitionParser.java
@@ -47,6 +47,7 @@ public class ZookeeperBeanDefinitionParser extends AbstractBeanDefinitionParser 
         configuration.addConstructorArgValue(element.getAttribute("namespace"));
         addPropertyValueIfNotEmpty("base-sleep-time-milliseconds", "baseSleepTimeMilliseconds", element, configuration);
         addPropertyValueIfNotEmpty("max-sleep-time-milliseconds", "maxSleepTimeMilliseconds", element, configuration);
+        addPropertyValueIfNotEmpty("max-retries", "maxRetries", element, configuration);
         addPropertyValueIfNotEmpty("session-timeout-milliseconds", "sessionTimeoutMilliseconds", element, configuration);
         addPropertyValueIfNotEmpty("connection-timeout-milliseconds", "connectionTimeoutMilliseconds", element, configuration);
         addPropertyValueIfNotEmpty("digest", "digest", element, configuration);


### PR DESCRIPTION
<reg:zookeeper/>里的max-retries不起作用，查看代码发现在解析命名空间的代码里，漏解析了这一参数。