### PR TITLE
Job全局顺序支持以及spring容器加载分片策略类

### DIFF
--- a/elastic-job-cloud/elastic-job-cloud-executor/src/main/java/com/dangdang/ddframe/job/cloud/executor/CloudJobFacade.java
+++ b/elastic-job-cloud/elastic-job-cloud-executor/src/main/java/com/dangdang/ddframe/job/cloud/executor/CloudJobFacade.java
@@ -118,4 +118,9 @@ public class CloudJobFacade implements JobFacade {
         jobEventBus.post(new JobStatusTraceEvent(taskContext.getMetaInfo().getJobName(), taskContext.getId(), taskContext.getSlaveId(), 
                 Source.CLOUD_EXECUTOR, taskContext.getType(), String.valueOf(taskContext.getMetaInfo().getShardingItems()), state, message));
     }
+
+    @Override
+    public boolean clusterOrderIfNecessary() {
+        return false;
+    }
 }

--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/executor/AbstractElasticJobExecutor.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/executor/AbstractElasticJobExecutor.java
@@ -104,6 +104,12 @@ public abstract class AbstractElasticJobExecutor {
         if (shardingContexts.isAllowSendJobEvent()) {
             jobFacade.postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_STAGING, String.format("Job '%s' execute begin.", jobName));
         }
+        if(jobFacade.clusterOrderIfNecessary()){
+            //当job需要全局顺序的时候，misfire是没意义的
+            jobFacade.postJobStatusTraceEvent(shardingContexts.getTaskId(),State.TASK_FINISHED,String.format(
+                    "This job '%s' need cluster order but currently still has node running,so return",jobName));
+            return;
+        }
         if (jobFacade.misfireIfNecessary(shardingContexts.getShardingItemParameters().keySet())) {
             if (shardingContexts.isAllowSendJobEvent()) {
                 jobFacade.postJobStatusTraceEvent(shardingContexts.getTaskId(), State.TASK_FINISHED, String.format(

--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/executor/JobFacade.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/executor/JobFacade.java
@@ -145,4 +145,9 @@ public interface JobFacade {
      * @param message 作业执行消息
      */
     void postJobStatusTraceEvent(String taskId, JobStatusTraceEvent.State state, String message);
+
+    /**
+     * 判断作业是否全局顺序
+     */
+    boolean clusterOrderIfNecessary();
 }

--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/util/json/AbstractJobConfigurationGsonTypeAdapter.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/util/json/AbstractJobConfigurationGsonTypeAdapter.java
@@ -65,43 +65,43 @@ public abstract class AbstractJobConfigurationGsonTypeAdapter<T extends JobRootC
         while (in.hasNext()) {
             String jsonName = in.nextName();
             switch (jsonName) {
-                case "jobName":
+                case JobCoreConfigurationConstants.JOB_NAME:
                     jobName = in.nextString();
                     break;
-                case "cron":
+                case JobCoreConfigurationConstants.JOB_CRON:
                     cron = in.nextString();
                     break;
-                case "shardingTotalCount":
+                case JobCoreConfigurationConstants.SHARDING_TOTAL_COUNT:
                     shardingTotalCount = in.nextInt();
                     break;
-                case "shardingItemParameters":
+                case JobCoreConfigurationConstants.SHARDING_ITEM_PARAMETERS:
                     shardingItemParameters = in.nextString();
                     break;
-                case "jobParameter":
+                case JobCoreConfigurationConstants.JOB_PARAMETER:
                     jobParameter = in.nextString();
                     break;
-                case "failover":
+                case JobCoreConfigurationConstants.FAIL_OVER:
                     failover = in.nextBoolean();
                     break;
-                case "misfire":
+                case JobCoreConfigurationConstants.MIS_FIRE:
                     misfire = in.nextBoolean();
                     break;
-                case "description":
+                case JobCoreConfigurationConstants.DESCRIPTION:
                     description = in.nextString();
                     break;
-                case "jobProperties":
+                case JobCoreConfigurationConstants.JOB_PROPERTIES:
                     jobProperties = getJobProperties(in);
                     break;
-                case "jobType":
+                case JobCoreConfigurationConstants.JOB_TYPE:
                     jobType = JobType.valueOf(in.nextString());
                     break;
-                case "jobClass":
+                case JobCoreConfigurationConstants.JOB_CLASS:
                     jobClass = in.nextString();
                     break;
-                case "streamingProcess":
+                case JobCoreConfigurationConstants.STREAMING_PROCESS:
                     streamingProcess = in.nextBoolean();
                     break;
-                case "scriptCommandLine":
+                case JobCoreConfigurationConstants.SCRIPT_COMMAND_LINE:
                     scriptCommandLine = in.nextString();
                     break;
                 default:
@@ -121,10 +121,10 @@ public abstract class AbstractJobConfigurationGsonTypeAdapter<T extends JobRootC
         in.beginObject();
         while (in.hasNext()) {
             switch (in.nextName()) {
-                case "job_exception_handler":
+                case JobCoreConfigurationConstants.JOB_EXCEPTION_HANDLER:
                     result.put(JobProperties.JobPropertiesEnum.JOB_EXCEPTION_HANDLER.getKey(), in.nextString());
                     break;
-                case "executor_service_handler":
+                case JobCoreConfigurationConstants.EXECUTOR_SERVICE_HANDLER:
                     result.put(JobProperties.JobPropertiesEnum.EXECUTOR_SERVICE_HANDLER.getKey(), in.nextString());
                     break;
                 default:
@@ -175,23 +175,23 @@ public abstract class AbstractJobConfigurationGsonTypeAdapter<T extends JobRootC
     @Override
     public void write(final JsonWriter out, final T value) throws IOException {
         out.beginObject();
-        out.name("jobName").value(value.getTypeConfig().getCoreConfig().getJobName());
-        out.name("jobClass").value(value.getTypeConfig().getJobClass());
-        out.name("jobType").value(value.getTypeConfig().getJobType().name());
-        out.name("cron").value(value.getTypeConfig().getCoreConfig().getCron());
-        out.name("shardingTotalCount").value(value.getTypeConfig().getCoreConfig().getShardingTotalCount());
-        out.name("shardingItemParameters").value(value.getTypeConfig().getCoreConfig().getShardingItemParameters());
-        out.name("jobParameter").value(value.getTypeConfig().getCoreConfig().getJobParameter());
-        out.name("failover").value(value.getTypeConfig().getCoreConfig().isFailover());
-        out.name("misfire").value(value.getTypeConfig().getCoreConfig().isMisfire());
-        out.name("description").value(value.getTypeConfig().getCoreConfig().getDescription());
-        out.name("jobProperties").jsonValue(value.getTypeConfig().getCoreConfig().getJobProperties().json());
+        out.name(JobCoreConfigurationConstants.JOB_NAME).value(value.getTypeConfig().getCoreConfig().getJobName());
+        out.name(JobCoreConfigurationConstants.JOB_CLASS).value(value.getTypeConfig().getJobClass());
+        out.name(JobCoreConfigurationConstants.JOB_TYPE).value(value.getTypeConfig().getJobType().name());
+        out.name(JobCoreConfigurationConstants.JOB_CRON).value(value.getTypeConfig().getCoreConfig().getCron());
+        out.name(JobCoreConfigurationConstants.SHARDING_TOTAL_COUNT).value(value.getTypeConfig().getCoreConfig().getShardingTotalCount());
+        out.name(JobCoreConfigurationConstants.SHARDING_ITEM_PARAMETERS).value(value.getTypeConfig().getCoreConfig().getShardingItemParameters());
+        out.name(JobCoreConfigurationConstants.JOB_PARAMETER).value(value.getTypeConfig().getCoreConfig().getJobParameter());
+        out.name(JobCoreConfigurationConstants.FAIL_OVER).value(value.getTypeConfig().getCoreConfig().isFailover());
+        out.name(JobCoreConfigurationConstants.MIS_FIRE).value(value.getTypeConfig().getCoreConfig().isMisfire());
+        out.name(JobCoreConfigurationConstants.DESCRIPTION).value(value.getTypeConfig().getCoreConfig().getDescription());
+        out.name(JobCoreConfigurationConstants.JOB_PROPERTIES).jsonValue(value.getTypeConfig().getCoreConfig().getJobProperties().json());
         if (value.getTypeConfig().getJobType() == JobType.DATAFLOW) {
             DataflowJobConfiguration dataflowJobConfig = (DataflowJobConfiguration) value.getTypeConfig();
-            out.name("streamingProcess").value(dataflowJobConfig.isStreamingProcess());
+            out.name(JobCoreConfigurationConstants.STREAMING_PROCESS).value(dataflowJobConfig.isStreamingProcess());
         } else if (value.getTypeConfig().getJobType() == JobType.SCRIPT) {
             ScriptJobConfiguration scriptJobConfig = (ScriptJobConfiguration) value.getTypeConfig();
-            out.name("scriptCommandLine").value(scriptJobConfig.getScriptCommandLine());
+            out.name(JobCoreConfigurationConstants.SCRIPT_COMMAND_LINE).value(scriptJobConfig.getScriptCommandLine());
         }
         writeCustomized(out, value);
         out.endObject();

--- a/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/util/json/JobCoreConfigurationConstants.java
+++ b/elastic-job-common/elastic-job-common-core/src/main/java/com/dangdang/ddframe/job/util/json/JobCoreConfigurationConstants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2015 dangdang.com.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package com.dangdang.ddframe.job.util.json;
+
+
+/**
+ * @author leizhenyu
+ *
+ * Job 配置属性的常量类
+ *
+ */
+public class JobCoreConfigurationConstants {
+
+    //JOB Core Configuration
+    public static final String JOB_NAME = "jobName";
+
+    public static final String JOB_CRON = "cron";
+
+    public static final String SHARDING_TOTAL_COUNT = "shardingTotalCount";
+
+    public static final String SHARDING_ITEM_PARAMETERS = "shardingItemParameters";
+
+    public static final String JOB_PARAMETER = "jobParameter";
+
+    public static final String FAIL_OVER  = "failover";
+
+    public static final String MIS_FIRE = "misfire";
+
+    public static final String DESCRIPTION = "description";
+
+    public static final String JOB_PROPERTIES = "jobProperties";
+
+    public static final String JOB_TYPE = "jobType";
+
+    public static final String JOB_CLASS = "jobClass";
+
+    public static final String STREAMING_PROCESS = "streamingProcess";
+
+    public static final String SCRIPT_COMMAND_LINE = "scriptCommandLine";
+
+    public static final String JOB_EXCEPTION_HANDLER = "job_exception_handler";
+
+    public static final String EXECUTOR_SERVICE_HANDLER = "executor_service_handler";
+
+}

--- a/elastic-job-example/elastic-job-example-lite-java/src/main/java/com/dangdang/ddframe/job/example/JavaMain.java
+++ b/elastic-job-example/elastic-job-example-lite-java/src/main/java/com/dangdang/ddframe/job/example/JavaMain.java
@@ -68,8 +68,8 @@ public final class JavaMain {
         CoordinatorRegistryCenter regCenter = setUpRegistryCenter();
         JobEventConfiguration jobEventConfig = new JobEventRdbConfiguration(setUpEventTraceDataSource());
         setUpSimpleJob(regCenter, jobEventConfig);
-        //setUpDataflowJob(regCenter, jobEventConfig);
-        //setUpScriptJob(regCenter, jobEventConfig);
+        setUpDataflowJob(regCenter, jobEventConfig);
+        setUpScriptJob(regCenter, jobEventConfig);
     }
     
     private static CoordinatorRegistryCenter setUpRegistryCenter() {
@@ -91,13 +91,13 @@ public final class JavaMain {
     private static void setUpSimpleJob(final CoordinatorRegistryCenter regCenter, final JobEventConfiguration jobEventConfig) {
         JobCoreConfiguration coreConfig = JobCoreConfiguration.newBuilder("javaSimpleJob", "0/5 * * * * ?", 3).shardingItemParameters("0=Beijing,1=Shanghai,2=Guangzhou").build();
         SimpleJobConfiguration simpleJobConfig = new SimpleJobConfiguration(coreConfig, JavaSimpleJob.class.getCanonicalName());
-        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(simpleJobConfig).overwrite(true).clusterOrdeer(true).build(), jobEventConfig, new JavaSimpleListener(), new JavaSimpleDistributeListener(1000L, 2000L)).init();
+        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(simpleJobConfig).clusterOrdeer(true).build(), jobEventConfig, new JavaSimpleListener(), new JavaSimpleDistributeListener(1000L, 2000L)).init();
     }
     
     private static void setUpDataflowJob(final CoordinatorRegistryCenter regCenter, final JobEventConfiguration jobEventConfig) {
         JobCoreConfiguration coreConfig = JobCoreConfiguration.newBuilder("javaDataflowElasticJob", "0/5 * * * * ?", 3).shardingItemParameters("0=Beijing,1=Shanghai,2=Guangzhou").build();
         DataflowJobConfiguration dataflowJobConfig = new DataflowJobConfiguration(coreConfig, JavaDataflowJob.class.getCanonicalName(), true);
-        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(dataflowJobConfig).build(), jobEventConfig).init();
+        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(dataflowJobConfig).clusterOrdeer(true).build(), jobEventConfig).init();
     }
     
     private static void setUpScriptJob(final CoordinatorRegistryCenter regCenter, final JobEventConfiguration jobEventConfig) throws IOException {

--- a/elastic-job-example/elastic-job-example-lite-java/src/main/java/com/dangdang/ddframe/job/example/JavaMain.java
+++ b/elastic-job-example/elastic-job-example-lite-java/src/main/java/com/dangdang/ddframe/job/example/JavaMain.java
@@ -68,8 +68,8 @@ public final class JavaMain {
         CoordinatorRegistryCenter regCenter = setUpRegistryCenter();
         JobEventConfiguration jobEventConfig = new JobEventRdbConfiguration(setUpEventTraceDataSource());
         setUpSimpleJob(regCenter, jobEventConfig);
-        setUpDataflowJob(regCenter, jobEventConfig);
-        setUpScriptJob(regCenter, jobEventConfig);
+        //setUpDataflowJob(regCenter, jobEventConfig);
+        //setUpScriptJob(regCenter, jobEventConfig);
     }
     
     private static CoordinatorRegistryCenter setUpRegistryCenter() {
@@ -91,7 +91,7 @@ public final class JavaMain {
     private static void setUpSimpleJob(final CoordinatorRegistryCenter regCenter, final JobEventConfiguration jobEventConfig) {
         JobCoreConfiguration coreConfig = JobCoreConfiguration.newBuilder("javaSimpleJob", "0/5 * * * * ?", 3).shardingItemParameters("0=Beijing,1=Shanghai,2=Guangzhou").build();
         SimpleJobConfiguration simpleJobConfig = new SimpleJobConfiguration(coreConfig, JavaSimpleJob.class.getCanonicalName());
-        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(simpleJobConfig).build(), jobEventConfig, new JavaSimpleListener(), new JavaSimpleDistributeListener(1000L, 2000L)).init();
+        new JobScheduler(regCenter, LiteJobConfiguration.newBuilder(simpleJobConfig).overwrite(true).clusterOrdeer(true).build(), jobEventConfig, new JavaSimpleListener(), new JavaSimpleDistributeListener(1000L, 2000L)).init();
     }
     
     private static void setUpDataflowJob(final CoordinatorRegistryCenter regCenter, final JobEventConfiguration jobEventConfig) {

--- a/elastic-job-example/elastic-job-example-lite-java/src/main/resources/logback.xml
+++ b/elastic-job-example/elastic-job-example-lite-java/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
     </appender>
     
     <root>
-        <level value="INFO" />
+        <level value="debug" />
         <appender-ref ref="STDOUT" />
     </root>
     

--- a/elastic-job-example/elastic-job-example-lite-spring/src/main/resources/META-INF/applicationContext.xml
+++ b/elastic-job-example/elastic-job-example-lite-spring/src/main/resources/META-INF/applicationContext.xml
@@ -25,7 +25,7 @@
     
     <reg:zookeeper id="regCenter" server-lists="${serverLists}" namespace="${namespace}" base-sleep-time-milliseconds="${baseSleepTimeMilliseconds}" max-sleep-time-milliseconds="${maxSleepTimeMilliseconds}" max-retries="${maxRetries}" />
     
-    <job:simple id="${simple.id}" class="${simple.class}" registry-center-ref="regCenter" sharding-total-count="${simple.shardingTotalCount}" cron="${simple.cron}" sharding-item-parameters="${simple.shardingItemParameters}" monitor-execution="${simple.monitorExecution}" monitor-port="${simple.monitorPort}" failover="${simple.failover}" description="${simple.description}" disabled="${simple.disabled}" overwrite="${simple.overwrite}" event-trace-rdb-data-source="elasticJobLog">
+    <job:simple id="${simple.id}" class="${simple.class}" registry-center-ref="regCenter" sharding-total-count="${simple.shardingTotalCount}" cron="${simple.cron}" sharding-item-parameters="${simple.shardingItemParameters}" monitor-execution="${simple.monitorExecution}" monitor-port="${simple.monitorPort}" failover="${simple.failover}" description="${simple.description}" disabled="${simple.disabled}" overwrite="${simple.overwrite}" event-trace-rdb-data-source="elasticJobLog" clusterOrder="${simple.clusterOrder}">
         <job:listener class="${listener.simple}" />
         <job:distributed-listener class="${listener.distributed}" started-timeout-milliseconds="${listener.distributed.startedTimeoutMilliseconds}" completed-timeout-milliseconds="${listener.distributed.completedTimeoutMilliseconds}" />
     </job:simple>

--- a/elastic-job-example/elastic-job-example-lite-spring/src/main/resources/conf/job.properties
+++ b/elastic-job-example/elastic-job-example-lite-spring/src/main/resources/conf/job.properties
@@ -19,6 +19,7 @@ simple.description=\u53EA\u8FD0\u884C\u4E00\u6B21\u7684\u4F5C\u4E1A\u793A\u4F8B
 simple.disabled=false
 simple.overwrite=true
 simple.monitorPort=9888
+simple.clusterOrder=true
 
 dataflow.id=springDataflowJob
 dataflow.class=com.dangdang.ddframe.job.example.job.dataflow.SpringDataflowJob

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/DefaultJobShardingStrategyFactory.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/DefaultJobShardingStrategyFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2015 dangdang.com.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package com.dangdang.ddframe.job.lite.api.strategy;
+
+import com.dangdang.ddframe.job.exception.JobConfigurationException;
+import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShardingStrategy;
+import com.google.common.base.Strings;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 作业分片策略工厂.
+ * 
+ * @author zhangliang
+ */
+public class DefaultJobShardingStrategyFactory implements JobShardingStrategyFactory{
+    
+    /**
+     * 获取 作业分片策略实例.
+     * 
+     * @param jobShardingStrategyClassName 作业分片策略类名
+     * @return 作业分片策略实例
+     */
+    public JobShardingStrategy getStrategy(final String jobShardingStrategyClassName) {
+        if (Strings.isNullOrEmpty(jobShardingStrategyClassName)) {
+            return null;
+        }
+        try {
+            Class<?> jobShardingStrategyClass = Class.forName(jobShardingStrategyClassName);
+            if (!JobShardingStrategy.class.isAssignableFrom(jobShardingStrategyClass)) {
+                throw new JobConfigurationException("Class '%s' is not job strategy class", jobShardingStrategyClassName);
+            }
+            return (JobShardingStrategy) jobShardingStrategyClass.newInstance();
+        } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+            throw new JobConfigurationException("Sharding strategy class '%s' config error, message details are '%s'", jobShardingStrategyClassName, ex.getMessage());
+        }
+    }
+}

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactory.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactory.java
@@ -14,41 +14,16 @@
  * limitations under the License.
  * </p>
  */
-
 package com.dangdang.ddframe.job.lite.api.strategy;
 
-import com.dangdang.ddframe.job.exception.JobConfigurationException;
-import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShardingStrategy;
-import com.google.common.base.Strings;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 /**
- * 作业分片策略工厂.
- * 
- * @author zhangliang
+ * @author leizhenyu
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class JobShardingStrategyFactory {
-    
+public interface JobShardingStrategyFactory {
     /**
-     * 获取 作业分片策略实例.
-     * 
-     * @param jobShardingStrategyClassName 作业分片策略类名
-     * @return 作业分片策略实例
+     * 根据分片策略类名，加载此类的实例
+     * @param jobShardingStrategyClassName
+     * @return
      */
-    public static JobShardingStrategy getStrategy(final String jobShardingStrategyClassName) {
-        if (Strings.isNullOrEmpty(jobShardingStrategyClassName)) {
-            return new AverageAllocationJobShardingStrategy();
-        }
-        try {
-            Class<?> jobShardingStrategyClass = Class.forName(jobShardingStrategyClassName);
-            if (!JobShardingStrategy.class.isAssignableFrom(jobShardingStrategyClass)) {
-                throw new JobConfigurationException("Class '%s' is not job strategy class", jobShardingStrategyClassName);
-            }
-            return (JobShardingStrategy) jobShardingStrategyClass.newInstance();
-        } catch (final ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            throw new JobConfigurationException("Sharding strategy class '%s' config error, message details are '%s'", jobShardingStrategyClassName, ex.getMessage());
-        }
-    }
+    JobShardingStrategy getStrategy(String jobShardingStrategyClassName);
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyService.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyService.java
@@ -46,7 +46,6 @@ public class JobShardingStrategyService {
      * @return job 分片类策略工厂
      */
     private void initJobShardingStrategyFactory(){
-        List<JobShardingStrategyFactory> jobShardingStrategyFactories = Lists.newArrayList();
         JobShardingStrategyFactory failBackJobShardingStrgtegyFactory = null;
 
         //将默认的策略分片工厂类作为fallback，加在list的最后面。避免出现默认的排在第一而所有的策略类被默认的工厂类初始化

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyService.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyService.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 1999-2015 dangdang.com.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+package com.dangdang.ddframe.job.lite.api.strategy;
+
+import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShardingStrategy;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * @author leizhenyu
+ */
+public class JobShardingStrategyService {
+
+    private final ServiceLoader<JobShardingStrategyFactory> jobShardingStrategyFactoryServiceLoader;
+
+    private final List<JobShardingStrategyFactory> factories = Lists.newArrayList();
+
+    public JobShardingStrategyService(){
+        jobShardingStrategyFactoryServiceLoader = ServiceLoader.load(JobShardingStrategyFactory.class);
+        init();
+    }
+
+    private void init(){
+        initJobShardingStrategyFactory();
+    }
+
+    /**
+     * 从serviceloader 中获取job分片工厂类
+     * 路径是 /META-INF/services
+     * @return job 分片类策略工厂
+     */
+    private void initJobShardingStrategyFactory(){
+        List<JobShardingStrategyFactory> jobShardingStrategyFactories = Lists.newArrayList();
+        JobShardingStrategyFactory failBackJobShardingStrgtegyFactory = null;
+
+        //将默认的策略分片工厂类作为fallback，加在list的最后面。避免出现默认的排在第一而所有的策略类被默认的工厂类初始化
+        for(JobShardingStrategyFactory factory : jobShardingStrategyFactoryServiceLoader){
+            if(factory != null) {
+                if(!(factory instanceof DefaultJobShardingStrategyFactory)) {
+                    factories.add(factory);
+                }else {
+                    failBackJobShardingStrgtegyFactory = factory;
+                }
+            }
+        }
+
+        if(failBackJobShardingStrgtegyFactory != null) {
+            factories.add(failBackJobShardingStrgtegyFactory);
+        }
+    }
+
+    /**
+     * 根据类名，获取job分片实例，如果找不到，就直接返回默认的。
+     * @param stragetyClassName
+     * @return
+     */
+    public JobShardingStrategy getJobShardingStrategy(String stragetyClassName){
+        if (factories == null || factories.isEmpty()){
+            //return default.
+            return new AverageAllocationJobShardingStrategy();
+        }
+        for(JobShardingStrategyFactory factory : factories){
+            JobShardingStrategy jobShardingStrategy = factory.getStrategy(stragetyClassName);
+            if (jobShardingStrategy != null){
+                return jobShardingStrategy;
+            }
+        }
+
+        return new AverageAllocationJobShardingStrategy();
+    }
+
+
+}

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/config/LiteJobConfiguration.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/config/LiteJobConfiguration.java
@@ -49,6 +49,8 @@ public class LiteJobConfiguration implements JobRootConfiguration {
     private final boolean overwrite;
     
     private final int reconcileIntervalMinutes;
+
+    private final boolean clusterOrder;
     
     /**
      * 获取作业名称.
@@ -96,6 +98,8 @@ public class LiteJobConfiguration implements JobRootConfiguration {
         private boolean overwrite;
         
         private int reconcileIntervalMinutes = -1;
+
+        private boolean clusterOrder = false;
         
         /**
          * 设置监控作业执行时状态.
@@ -208,6 +212,22 @@ public class LiteJobConfiguration implements JobRootConfiguration {
             this.reconcileIntervalMinutes = reconcileIntervalMinutes;
             return this;
         }
+
+        /**
+         * 设置作业是否需要全局顺序
+         *
+         * <p>
+         *   如果整个集群中此任务的前一次触发还没有执行完，那么后续不能触发。
+         * </p>
+         *
+         * @param clusterOrder 是否需要全局顺序
+         *
+         * @return lite作业配置构建器
+         */
+        public Builder clusterOrdeer(final boolean clusterOrder){
+            this.clusterOrder = clusterOrder;
+            return this;
+        }
         
         /**
          * 构建作业配置对象.
@@ -215,7 +235,7 @@ public class LiteJobConfiguration implements JobRootConfiguration {
          * @return 作业配置对象
          */
         public final LiteJobConfiguration build() {
-            return new LiteJobConfiguration(jobConfig, monitorExecution, maxTimeDiffSeconds, monitorPort, jobShardingStrategyClass, disabled, overwrite, reconcileIntervalMinutes);
+            return new LiteJobConfiguration(jobConfig, monitorExecution, maxTimeDiffSeconds, monitorPort, jobShardingStrategyClass, disabled, overwrite, reconcileIntervalMinutes,clusterOrder);
         }
     }
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationConstants.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationConstants.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2015 dangdang.com.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+package com.dangdang.ddframe.job.lite.internal.config;
+
+/**
+ * @author leizhenyu
+ * list job 配置的常量类
+ */
+public class LiteJobConfigurationConstants {
+
+    public static final String MONITOR_EXECUTION = "monitorExecution";
+
+    public static final String MAX_TIME_DIFF_SECONDS = "maxTimeDiffSeconds";
+
+    public static final String MONITOR_PORT = "monitorPort";
+
+    public static final String JOB_SHARDING_STRATEGY_CLASS = "jobShardingStrategyClass";
+
+    public static final String DISABLED = "disabled";
+
+    public static final String OVER_WRITE = "overwrite";
+
+    public static final String RECONCILE_INTERVAL_MINUTES = "reconcileIntervalMinutes";
+
+    public static final String CLUSTER_ORDER = "clusterOrder";
+}

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactory.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactory.java
@@ -81,27 +81,29 @@ public final class LiteJobConfigurationGsonFactory {
         @Override
         protected void addToCustomizedValueMap(final String jsonName, final JsonReader in, final Map<String, Object> customizedValueMap) throws IOException {
             switch (jsonName) {
-                case "monitorExecution":
-                    customizedValueMap.put("monitorExecution", in.nextBoolean());
+                case LiteJobConfigurationConstants.MONITOR_EXECUTION:
+                    customizedValueMap.put(LiteJobConfigurationConstants.MONITOR_EXECUTION, in.nextBoolean());
                     break;
-                case "maxTimeDiffSeconds":
-                    customizedValueMap.put("maxTimeDiffSeconds", in.nextInt());
+                case LiteJobConfigurationConstants.MAX_TIME_DIFF_SECONDS:
+                    customizedValueMap.put(LiteJobConfigurationConstants.MAX_TIME_DIFF_SECONDS, in.nextInt());
                     break;
-                case "monitorPort":
-                    customizedValueMap.put("monitorPort", in.nextInt());
+                case LiteJobConfigurationConstants.MONITOR_PORT:
+                    customizedValueMap.put(LiteJobConfigurationConstants.MONITOR_PORT, in.nextInt());
                     break;
-                case "jobShardingStrategyClass":
-                    customizedValueMap.put("jobShardingStrategyClass", in.nextString());
+                case LiteJobConfigurationConstants.JOB_SHARDING_STRATEGY_CLASS:
+                    customizedValueMap.put(LiteJobConfigurationConstants.JOB_SHARDING_STRATEGY_CLASS, in.nextString());
                     break;
-                case "disabled":
-                    customizedValueMap.put("disabled", in.nextBoolean());
+                case LiteJobConfigurationConstants.DISABLED:
+                    customizedValueMap.put(LiteJobConfigurationConstants.DISABLED, in.nextBoolean());
                     break;
-                case "overwrite":
-                    customizedValueMap.put("overwrite", in.nextBoolean());
+                case LiteJobConfigurationConstants.OVER_WRITE:
+                    customizedValueMap.put(LiteJobConfigurationConstants.OVER_WRITE, in.nextBoolean());
                     break;
-                case "reconcileIntervalMinutes":
-                    customizedValueMap.put("reconcileIntervalMinutes", in.nextInt());
+                case LiteJobConfigurationConstants.RECONCILE_INTERVAL_MINUTES:
+                    customizedValueMap.put(LiteJobConfigurationConstants.RECONCILE_INTERVAL_MINUTES, in.nextInt());
                     break;
+                case LiteJobConfigurationConstants.CLUSTER_ORDER:
+                    customizedValueMap.put(LiteJobConfigurationConstants.CLUSTER_ORDER,in.nextBoolean());
                 default:
                     in.skipValue();
                     break;
@@ -111,39 +113,43 @@ public final class LiteJobConfigurationGsonFactory {
         @Override
         protected LiteJobConfiguration getJobRootConfiguration(final JobTypeConfiguration typeConfig, final Map<String, Object> customizedValueMap) {
             LiteJobConfiguration.Builder builder = LiteJobConfiguration.newBuilder(typeConfig);
-            if (customizedValueMap.containsKey("monitorExecution")) {
-                builder.monitorExecution((boolean) customizedValueMap.get("monitorExecution"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.MONITOR_EXECUTION)) {
+                builder.monitorExecution((boolean) customizedValueMap.get(LiteJobConfigurationConstants.MONITOR_EXECUTION));
             }
-            if (customizedValueMap.containsKey("maxTimeDiffSeconds")) {
-                builder.maxTimeDiffSeconds((int) customizedValueMap.get("maxTimeDiffSeconds"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.MAX_TIME_DIFF_SECONDS)) {
+                builder.maxTimeDiffSeconds((int) customizedValueMap.get(LiteJobConfigurationConstants.MAX_TIME_DIFF_SECONDS));
             }
-            if (customizedValueMap.containsKey("monitorPort")) {
-                builder.monitorPort((int) customizedValueMap.get("monitorPort"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.MONITOR_PORT)) {
+                builder.monitorPort((int) customizedValueMap.get(LiteJobConfigurationConstants.MONITOR_PORT));
             }
-            if (customizedValueMap.containsKey("jobShardingStrategyClass")) {
-                builder.jobShardingStrategyClass((String) customizedValueMap.get("jobShardingStrategyClass"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.JOB_SHARDING_STRATEGY_CLASS)) {
+                builder.jobShardingStrategyClass((String) customizedValueMap.get(LiteJobConfigurationConstants.JOB_SHARDING_STRATEGY_CLASS));
             }
-            if (customizedValueMap.containsKey("disabled")) {
-                builder.disabled((boolean) customizedValueMap.get("disabled"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.DISABLED)) {
+                builder.disabled((boolean) customizedValueMap.get(LiteJobConfigurationConstants.DISABLED));
             }
-            if (customizedValueMap.containsKey("overwrite")) {
-                builder.overwrite((boolean) customizedValueMap.get("overwrite"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.OVER_WRITE)) {
+                builder.overwrite((boolean) customizedValueMap.get(LiteJobConfigurationConstants.OVER_WRITE));
             }
-            if (customizedValueMap.containsKey("reconcileIntervalMinutes")) {
-                builder.reconcileIntervalMinutes((int) customizedValueMap.get("reconcileIntervalMinutes"));
+            if (customizedValueMap.containsKey(LiteJobConfigurationConstants.RECONCILE_INTERVAL_MINUTES)) {
+                builder.reconcileIntervalMinutes((int) customizedValueMap.get(LiteJobConfigurationConstants.RECONCILE_INTERVAL_MINUTES));
+            }
+            if(customizedValueMap.containsKey(LiteJobConfigurationConstants.CLUSTER_ORDER)){
+                builder.clusterOrdeer((boolean)customizedValueMap.get(LiteJobConfigurationConstants.CLUSTER_ORDER));
             }
             return builder.build();
         }
     
         @Override
         protected void writeCustomized(final JsonWriter out, final LiteJobConfiguration value) throws IOException {
-            out.name("monitorExecution").value(value.isMonitorExecution());
-            out.name("maxTimeDiffSeconds").value(value.getMaxTimeDiffSeconds());
-            out.name("monitorPort").value(value.getMonitorPort());
-            out.name("jobShardingStrategyClass").value(value.getJobShardingStrategyClass());
-            out.name("disabled").value(value.isDisabled());
-            out.name("overwrite").value(value.isOverwrite());
-            out.name("reconcileIntervalMinutes").value(value.getReconcileIntervalMinutes());
+            out.name(LiteJobConfigurationConstants.MONITOR_EXECUTION).value(value.isMonitorExecution());
+            out.name(LiteJobConfigurationConstants.MAX_TIME_DIFF_SECONDS).value(value.getMaxTimeDiffSeconds());
+            out.name(LiteJobConfigurationConstants.MONITOR_PORT).value(value.getMonitorPort());
+            out.name(LiteJobConfigurationConstants.JOB_SHARDING_STRATEGY_CLASS).value(value.getJobShardingStrategyClass());
+            out.name(LiteJobConfigurationConstants.DISABLED).value(value.isDisabled());
+            out.name(LiteJobConfigurationConstants.OVER_WRITE).value(value.isOverwrite());
+            out.name(LiteJobConfigurationConstants.RECONCILE_INTERVAL_MINUTES).value(value.getReconcileIntervalMinutes());
+            out.name(LiteJobConfigurationConstants.CLUSTER_ORDER).value(value.isClusterOrder());
         }
     }
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactory.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactory.java
@@ -104,6 +104,7 @@ public final class LiteJobConfigurationGsonFactory {
                     break;
                 case LiteJobConfigurationConstants.CLUSTER_ORDER:
                     customizedValueMap.put(LiteJobConfigurationConstants.CLUSTER_ORDER,in.nextBoolean());
+                    break;
                 default:
                     in.skipValue();
                     break;

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/execution/ExecutionService.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/execution/ExecutionService.java
@@ -175,6 +175,17 @@ public class ExecutionService {
         }
         return false;
     }
+
+    /**
+     * 如果还有分片项没有执行完，返回true。
+     * @return 全局
+     */
+    public boolean clusterOrderIfNecessary(){
+        if(hasRunningItems()){
+            return true;
+        }
+        return false;
+    }
     
     /**
      * 设置任务被错过执行的标记.

--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/schedule/LiteJobFacade.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/schedule/LiteJobFacade.java
@@ -185,4 +185,9 @@ public class LiteJobFacade implements JobFacade {
             log.trace(message);
         }
     }
+
+    @Override
+    public boolean clusterOrderIfNecessary() {
+       return  loadJobRootConfiguration(true).isClusterOrder() && executionService.clusterOrderIfNecessary();
+    }
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/main/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
@@ -1,0 +1,1 @@
+com.dangdang.ddframe.job.lite.api.strategy.DefaultJobShardingStrategyFactory

--- a/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactoryTest.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactoryTest.java
@@ -23,7 +23,13 @@ import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShard
 import org.junit.Before;
 import org.junit.Test;
 
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class JobShardingStrategyFactoryTest {
@@ -59,5 +65,13 @@ public class JobShardingStrategyFactoryTest {
     @Test
     public void assertGetStrategySuccess() {
         assertThat(jobShardingStrategyService.getJobShardingStrategy(AverageAllocationJobShardingStrategy.class.getName()), instanceOf(AverageAllocationJobShardingStrategy.class));
+    }
+
+    @Test
+    public void assertOnlyOneStrategyFactoryClass()throws Exception{
+        Field field = jobShardingStrategyService.getClass().getDeclaredField("factories");
+        field.setAccessible(true);
+        List lists =(List) field.get(new JobShardingStrategyService());
+        assertEquals(lists.size(),1);
     }
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactoryTest.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/api/strategy/JobShardingStrategyFactoryTest.java
@@ -20,35 +20,44 @@ package com.dangdang.ddframe.job.lite.api.strategy;
 import com.dangdang.ddframe.job.exception.JobConfigurationException;
 import com.dangdang.ddframe.job.lite.api.strategy.fixture.InvalidJobShardingStrategy;
 import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShardingStrategy;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 public class JobShardingStrategyFactoryTest {
+
+    private JobShardingStrategyService jobShardingStrategyService;
+
+    @Before
+    public void setUp(){
+        jobShardingStrategyService = new JobShardingStrategyService();
+    }
+
     
     @Test
     public void assertGetDefaultStrategy() {
-        assertThat(JobShardingStrategyFactory.getStrategy(null), instanceOf(AverageAllocationJobShardingStrategy.class));
+        assertThat(jobShardingStrategyService.getJobShardingStrategy(null), instanceOf(AverageAllocationJobShardingStrategy.class));
     }
     
     @Test(expected = JobConfigurationException.class)
     public void assertGetStrategyFailureWhenClassNotFound() {
-        JobShardingStrategyFactory.getStrategy("NotClass");
+        jobShardingStrategyService.getJobShardingStrategy("NotClass");
     }
     
     @Test(expected = JobConfigurationException.class)
     public void assertGetStrategyFailureWhenNotStrategyClass() {
-        JobShardingStrategyFactory.getStrategy(Object.class.getName());
+        jobShardingStrategyService.getJobShardingStrategy(Object.class.getName());
     }
     
     @Test(expected = JobConfigurationException.class)
     public void assertGetStrategyFailureWhenStrategyClassInvalid() {
-        JobShardingStrategyFactory.getStrategy(InvalidJobShardingStrategy.class.getName());
+        jobShardingStrategyService.getJobShardingStrategy(InvalidJobShardingStrategy.class.getName());
     }
     
     @Test
     public void assertGetStrategySuccess() {
-        assertThat(JobShardingStrategyFactory.getStrategy(AverageAllocationJobShardingStrategy.class.getName()), instanceOf(AverageAllocationJobShardingStrategy.class));
+        assertThat(jobShardingStrategyService.getJobShardingStrategy(AverageAllocationJobShardingStrategy.class.getName()), instanceOf(AverageAllocationJobShardingStrategy.class));
     }
 }

--- a/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/config/LiteJobConfigurationTest.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/config/LiteJobConfigurationTest.java
@@ -33,7 +33,7 @@ public final class LiteJobConfigurationTest {
     public void assertBuildAllProperties() {
         LiteJobConfiguration actual = LiteJobConfiguration.newBuilder(
                 new SimpleJobConfiguration(JobCoreConfiguration.newBuilder("test_job", "0/1 * * * * ?", 3).build(), TestSimpleJob.class.getCanonicalName()))
-                .monitorExecution(false).maxTimeDiffSeconds(1000).monitorPort(8888).jobShardingStrategyClass("testClass").disabled(true).overwrite(true).reconcileIntervalMinutes(60).build();
+                .monitorExecution(false).maxTimeDiffSeconds(1000).monitorPort(8888).jobShardingStrategyClass("testClass").disabled(true).overwrite(true).reconcileIntervalMinutes(60).clusterOrdeer(true).build();
         assertFalse(actual.isMonitorExecution());
         assertThat(actual.getMaxTimeDiffSeconds(), is(1000));
         assertThat(actual.getMonitorPort(), is(8888));
@@ -41,6 +41,7 @@ public final class LiteJobConfigurationTest {
         assertTrue(actual.isDisabled());
         assertTrue(actual.isOverwrite());
         assertThat(actual.getReconcileIntervalMinutes(), is(60));
+        assertTrue(actual.isClusterOrder());
     }
     
     @Test
@@ -53,6 +54,7 @@ public final class LiteJobConfigurationTest {
         assertThat(actual.getJobShardingStrategyClass(), is(""));
         assertFalse(actual.isDisabled());
         assertFalse(actual.isOverwrite());
+        assertFalse(actual.isClusterOrder());
     }
     
     @Test

--- a/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactoryTest.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/test/java/com/dangdang/ddframe/job/lite/internal/config/LiteJobConfigurationGsonFactoryTest.java
@@ -44,17 +44,17 @@ public final class LiteJobConfigurationGsonFactoryTest {
     private String simpleJobJson =  "{\"jobName\":\"test_job\",\"jobClass\":\"com.dangdang.ddframe.job.lite.fixture.TestSimpleJob\",\"jobType\":\"SIMPLE\",\"cron\":\"0/1 * * * * ?\","
             + "\"shardingTotalCount\":3,\"shardingItemParameters\":\"\",\"jobParameter\":\"\",\"failover\":true,\"misfire\":false,\"description\":\"\","
             + "\"jobProperties\":" + JOB_PROPS_JSON + ",\"monitorExecution\":false,\"maxTimeDiffSeconds\":1000,\"monitorPort\":8888,"
-            + "\"jobShardingStrategyClass\":\"testClass\",\"disabled\":true,\"overwrite\":true,\"reconcileIntervalMinutes\":15}";
+            + "\"jobShardingStrategyClass\":\"testClass\",\"disabled\":true,\"overwrite\":true,\"reconcileIntervalMinutes\":15,\"clusterOrder\":false}";
     
     private String dataflowJobJson = "{\"jobName\":\"test_job\",\"jobClass\":\"com.dangdang.ddframe.job.lite.fixture.TestDataflowJob\",\"jobType\":\"DATAFLOW\",\"cron\":\"0/1 * * * * ?\","
             + "\"shardingTotalCount\":3,\"shardingItemParameters\":\"\",\"jobParameter\":\"\",\"failover\":false,\"misfire\":true,\"description\":\"\","
             + "\"jobProperties\":" + JOB_PROPS_JSON + ",\"streamingProcess\":true,"
-            + "\"monitorExecution\":true,\"maxTimeDiffSeconds\":-1,\"monitorPort\":-1,\"jobShardingStrategyClass\":\"\",\"disabled\":false,\"overwrite\":false,\"reconcileIntervalMinutes\":-1}";
+            + "\"monitorExecution\":true,\"maxTimeDiffSeconds\":-1,\"monitorPort\":-1,\"jobShardingStrategyClass\":\"\",\"disabled\":false,\"overwrite\":false,\"reconcileIntervalMinutes\":-1,\"clusterOrder\":false}";
     
     private String scriptJobJson = "{\"jobName\":\"test_job\",\"jobClass\":\"com.dangdang.ddframe.job.api.script.ScriptJob\",\"jobType\":\"SCRIPT\",\"cron\":\"0/1 * * * * ?\","
             + "\"shardingTotalCount\":3,\"shardingItemParameters\":\"\",\"jobParameter\":\"\",\"failover\":false,\"misfire\":true,\"description\":\"\","
             + "\"jobProperties\":" + JOB_PROPS_JSON + ",\"scriptCommandLine\":\"test.sh\",\"monitorExecution\":true,\"maxTimeDiffSeconds\":-1,\"monitorPort\":-1,"
-            + "\"jobShardingStrategyClass\":\"\",\"disabled\":false,\"overwrite\":false,\"reconcileIntervalMinutes\":-1}";
+            + "\"jobShardingStrategyClass\":\"\",\"disabled\":false,\"overwrite\":false,\"reconcileIntervalMinutes\":-1,\"clusterOrder\":false}";
     
     @Test
     public void assertToJsonForSimpleJob() {

--- a/elastic-job-lite/elastic-job-lite-core/src/test/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
+++ b/elastic-job-lite/elastic-job-lite-core/src/test/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
@@ -1,0 +1,1 @@
+com.dangdang.ddframe.job.lite.api.strategy.DefaultJobShardingStrategyFactory

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/SpringJobScheduler.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/SpringJobScheduler.java
@@ -22,9 +22,13 @@ import com.dangdang.ddframe.job.event.JobEventConfiguration;
 import com.dangdang.ddframe.job.lite.api.JobScheduler;
 import com.dangdang.ddframe.job.lite.api.listener.ElasticJobListener;
 import com.dangdang.ddframe.job.lite.config.LiteJobConfiguration;
+import com.dangdang.ddframe.job.lite.spring.api.strategy.SpringJobShardingStrategyFactory;
 import com.dangdang.ddframe.job.lite.spring.job.util.AopTargetUtils;
 import com.dangdang.ddframe.job.reg.base.CoordinatorRegistryCenter;
 import com.google.common.base.Optional;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 
 /**
  * 基于Spring的作业启动器.
@@ -32,7 +36,7 @@ import com.google.common.base.Optional;
  * @author caohao
  * @author zhangliang
  */
-public class SpringJobScheduler extends JobScheduler {
+public class SpringJobScheduler extends JobScheduler implements ApplicationContextAware{
     
     private final ElasticJob elasticJob;
     
@@ -58,5 +62,10 @@ public class SpringJobScheduler extends JobScheduler {
     @Override
     protected Optional<ElasticJob> createElasticJobInstance() {
         return Optional.fromNullable(elasticJob);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        SpringJobShardingStrategyFactory.addApplicationContext(applicationContext);
     }
 }

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/strategy/SpringJobShardingStrategyFactory.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/strategy/SpringJobShardingStrategyFactory.java
@@ -56,7 +56,7 @@ public class SpringJobShardingStrategyFactory implements JobShardingStrategyFact
                     throw new JobConfigurationException("Class '%s' load Failed", strategyClassName);
                 }catch (NoSuchBeanDefinitionException e){
                     //spring 容器的行为，如果不存在此类型的bean，直接抛异常，没有更优的办法，只好catch了，并且吞掉异常
-                    log.debug(String.format("No this class bean %s define in spring container.",strategyClassName));
+                    log.debug(String.format("No this class bean %s defined in spring container.",strategyClassName));
                     return null;
                 }
             }

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/strategy/SpringJobShardingStrategyFactory.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/api/strategy/SpringJobShardingStrategyFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2015 dangdang.com.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+package com.dangdang.ddframe.job.lite.spring.api.strategy;
+
+import com.dangdang.ddframe.job.exception.JobConfigurationException;
+import com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategy;
+import com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory;
+import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 从spring 容器中加载策略分片类
+ * @author leizhenyu
+ */
+@Slf4j
+public class SpringJobShardingStrategyFactory implements JobShardingStrategyFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringJobShardingStrategyFactory.class);
+
+    private static final Set<ApplicationContext> contexts = new HashSet<>();
+
+    @Override
+    public JobShardingStrategy getStrategy(String strategyClassName) {
+        if (Strings.isNullOrEmpty(strategyClassName)) {
+            return null;
+        }
+        if (!CollectionUtils.isEmpty(contexts)) {
+            for (ApplicationContext context : contexts) {
+                try {
+                    Object bean = context.getBean(Class.forName(strategyClassName));
+                    return (JobShardingStrategy) bean;
+                } catch (ClassNotFoundException e) {
+                    LOGGER.error("Load job sharding strategy class {} failed,cause class not found.", strategyClassName);
+                    throw new JobConfigurationException("Class '%s' load Failed", strategyClassName);
+                }catch (NoSuchBeanDefinitionException e){
+                    //spring 容器的行为，如果不存在此类型的bean，直接抛异常，没有更优的办法，只好catch了，并且吞掉异常
+                    log.debug(String.format("No this class bean %s define in spring container.",strategyClassName));
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static void addApplicationContext(ApplicationContext context) {
+        if (context != null) {
+            contexts.add(context);
+        }
+    }
+
+
+}

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/job/parser/common/AbstractJobBeanDefinitionParser.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/job/parser/common/AbstractJobBeanDefinitionParser.java
@@ -60,6 +60,7 @@ import static com.dangdang.ddframe.job.lite.spring.job.parser.common.BaseJobBean
 import static com.dangdang.ddframe.job.lite.spring.job.parser.common.BaseJobBeanDefinitionParserTag.SHARDING_ITEM_PARAMETERS_ATTRIBUTE;
 import static com.dangdang.ddframe.job.lite.spring.job.parser.common.BaseJobBeanDefinitionParserTag.SHARDING_TOTAL_COUNT_ATTRIBUTE;
 import static com.dangdang.ddframe.job.lite.spring.job.parser.common.BaseJobBeanDefinitionParserTag.RECONCILE_INTERVAL_MINUTES;
+import static com.dangdang.ddframe.job.lite.spring.job.parser.common.BaseJobBeanDefinitionParserTag.CLUSTER_ORDER;
 
 /**
  * 基本作业的命名空间解析器.
@@ -105,6 +106,7 @@ public abstract class AbstractJobBeanDefinitionParser extends AbstractBeanDefini
         result.addConstructorArgValue(element.getAttribute(DISABLED_ATTRIBUTE));
         result.addConstructorArgValue(element.getAttribute(OVERWRITE_ATTRIBUTE));
         result.addConstructorArgValue(element.getAttribute(RECONCILE_INTERVAL_MINUTES));
+        result.addConstructorArgValue(element.getAttribute(CLUSTER_ORDER));
         return result.getBeanDefinition();
     }
     

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/job/parser/common/BaseJobBeanDefinitionParserTag.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/java/com/dangdang/ddframe/job/lite/spring/job/parser/common/BaseJobBeanDefinitionParserTag.java
@@ -57,6 +57,8 @@ public final class BaseJobBeanDefinitionParserTag {
     public static final String DISABLED_ATTRIBUTE = "disabled";
     
     public static final String OVERWRITE_ATTRIBUTE = "overwrite";
+
+    public static final String CLUSTER_ORDER = "clusterOrder";
     
     public static final String LISTENER_TAG = "listener";
     

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/resources/META-INF/namespace/job.xsd
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/resources/META-INF/namespace/job.xsd
@@ -43,6 +43,7 @@
                 <xsd:attribute name="description" type="xsd:string" />
                 <xsd:attribute name="disabled" type="xsd:string" default="false"/>
                 <xsd:attribute name="overwrite" type="xsd:string" default="false"/>
+                <xsd:attribute name="clusterOrder" type="xsd:string" default="false"/>
                 <xsd:attribute name="executor-service-handler" type="xsd:string" default="com.dangdang.ddframe.job.executor.handler.impl.DefaultExecutorServiceHandler"/>
                 <xsd:attribute name="job-exception-handler" type="xsd:string" default="com.dangdang.ddframe.job.executor.handler.impl.DefaultJobExceptionHandler"/>
                 <xsd:attribute name="event-trace-rdb-data-source" type="xsd:string" />

--- a/elastic-job-lite/elastic-job-lite-spring/src/main/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
+++ b/elastic-job-lite/elastic-job-lite-spring/src/main/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
@@ -1,0 +1,1 @@
+com.dangdang.ddframe.job.lite.spring.api.strategy.SpringJobShardingStrategyFactory

--- a/elastic-job-lite/elastic-job-lite-spring/src/test/java/com/dangdang/ddframe/job/lite/spring/fixture/strategy/SpringSimpleStrategy.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/test/java/com/dangdang/ddframe/job/lite/spring/fixture/strategy/SpringSimpleStrategy.java
@@ -1,0 +1,51 @@
+package com.dangdang.ddframe.job.lite.spring.fixture.strategy;
+
+import com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategy;
+import com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyOption;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * @author leizhenyu
+ * 测试下spring加载分片类
+ * 逻辑就是Average
+ */
+public class SpringSimpleStrategy implements JobShardingStrategy {
+    @Override
+    public Map<String, List<Integer>> sharding(List<String> serversList, JobShardingStrategyOption option) {
+        if (serversList.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, List<Integer>> result = shardingAliquot(serversList, option.getShardingTotalCount());
+        addAliquant(serversList, option.getShardingTotalCount(), result);
+        return result;
+    }
+
+
+    private Map<String, List<Integer>> shardingAliquot(final List<String> serversList, final int shardingTotalCount) {
+        Map<String, List<Integer>> result = new LinkedHashMap<>(serversList.size());
+        int itemCountPerSharding = shardingTotalCount / serversList.size();
+        int count = 0;
+        for (String each : serversList) {
+            List<Integer> shardingItems = new ArrayList<>(itemCountPerSharding + 1);
+            for (int i = count * itemCountPerSharding; i < (count + 1) * itemCountPerSharding; i++) {
+                shardingItems.add(i);
+            }
+            result.put(each, shardingItems);
+            count++;
+        }
+        return result;
+    }
+
+    private void addAliquant(final List<String> serversList, final int shardingTotalCount, final Map<String, List<Integer>> shardingResult) {
+        int aliquant = shardingTotalCount % serversList.size();
+        int count = 0;
+        for (Map.Entry<String, List<Integer>> entry : shardingResult.entrySet()) {
+            if (count < aliquant) {
+                entry.getValue().add(shardingTotalCount / serversList.size() * serversList.size() + count);
+            }
+            count++;
+        }
+    }
+}

--- a/elastic-job-lite/elastic-job-lite-spring/src/test/java/com/dangdang/ddframe/job/lite/spring/job/SpringShardingStrategyFactoryTest.java
+++ b/elastic-job-lite/elastic-job-lite-spring/src/test/java/com/dangdang/ddframe/job/lite/spring/job/SpringShardingStrategyFactoryTest.java
@@ -1,0 +1,59 @@
+package com.dangdang.ddframe.job.lite.spring.job;
+
+import com.dangdang.ddframe.job.exception.JobConfigurationException;
+import com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyService;
+import com.dangdang.ddframe.job.lite.api.strategy.impl.AverageAllocationJobShardingStrategy;
+import com.dangdang.ddframe.job.lite.spring.api.strategy.SpringJobShardingStrategyFactory;
+import com.dangdang.ddframe.job.lite.spring.fixture.strategy.SpringSimpleStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author leizhenyu
+ */
+@ContextConfiguration(locations = "/META-INF/job/withJobShardStrategyProperties.xml")
+public class SpringShardingStrategyFactoryTest extends AbstractJUnit4SpringContextTests {
+
+    private JobShardingStrategyService jobShardingStrategyService;
+
+    @Before
+    public void setUp() {
+        jobShardingStrategyService = new JobShardingStrategyService();
+        SpringJobShardingStrategyFactory.addApplicationContext(applicationContext);
+    }
+
+    @Test
+    public void assertGetDefaultStrategy(){
+        assertThat(jobShardingStrategyService.getJobShardingStrategy(null), instanceOf(AverageAllocationJobShardingStrategy.class));
+    }
+
+    @Test(expected = JobConfigurationException.class)
+    public void assertGetStrategyFailureWhenClassNotFound() {
+        jobShardingStrategyService.getJobShardingStrategy("NotClass");
+    }
+
+    @Test
+    public void assertGetSuccessfulStrategy(){
+        assertThat(jobShardingStrategyService.getJobShardingStrategy("com.dangdang.ddframe.job.lite.spring.fixture.strategy.SpringSimpleStrategy"),instanceOf(SpringSimpleStrategy.class));
+    }
+
+    @Test
+    public void assertHasTwoStrategyFactoryClass()throws Exception{
+        Field field = jobShardingStrategyService.getClass().getDeclaredField("factories");
+        field.setAccessible(true);
+        List lists =(List) field.get(new JobShardingStrategyService());
+        assertEquals(lists.size(),2);
+    }
+
+
+
+}

--- a/elastic-job-lite/elastic-job-lite-spring/src/test/resources/META-INF/job/withJobShardStrategyProperties.xml
+++ b/elastic-job-lite/elastic-job-lite-spring/src/test/resources/META-INF/job/withJobShardStrategyProperties.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:job="http://www.dangdang.com/schema/ddframe/job"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans 
+                        http://www.springframework.org/schema/beans/spring-beans.xsd
+                        http://www.dangdang.com/schema/ddframe/job 
+                        http://www.dangdang.com/schema/ddframe/job/job.xsd 
+                        ">
+    <!--<import resource="base.xml"/>
+    <job:simple id="simpleElasticJob_namespace_job_properties" class="com.dangdang.ddframe.job.lite.spring.fixture.job.FooSimpleElasticJob" registry-center-ref="regCenter" cron="${simpleJob.cron}" sharding-total-count="${simpleJob.shardingTotalCount}" sharding-item-parameters="${simpleJob.shardingItemParameters}" disabled="${simpleJob.disabled}" overwrite="${simpleJob.overwrite}" executor-service-handler="com.dangdang.ddframe.job.lite.spring.fixture.handler.SimpleExecutorServiceHandler" />
+    <job:dataflow id="dataflowElasticJob_namespace_job_properties" class="com.dangdang.ddframe.job.lite.spring.fixture.job.DataflowElasticJob" registry-center-ref="regCenter" cron="0/1 * * * * ?" sharding-total-count="3" sharding-item-parameters="0=A,1=B,2=C" description="中文描述" overwrite="true" job-exception-handler="com.dangdang.ddframe.job.lite.spring.fixture.handler.SimpleJobExceptionHandler" />-->
+
+    <bean id="simpleStrategy" class="com.dangdang.ddframe.job.lite.spring.fixture.strategy.SpringSimpleStrategy"/>
+</beans>

--- a/elastic-job-lite/elastic-job-lite-spring/src/test/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
+++ b/elastic-job-lite/elastic-job-lite-spring/src/test/resources/META-INF/services/com.dangdang.ddframe.job.lite.api.strategy.JobShardingStrategyFactory
@@ -1,0 +1,1 @@
+com.dangdang.ddframe.job.lite.spring.api.strategy.SpringJobShardingStrategyFactory

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
         <module>elastic-job-common</module>
         <module>elastic-job-lite</module>
         <module>elastic-job-cloud</module>
-        <module>elastic-job-example</module>
     </modules>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>elastic-job-common</module>
         <module>elastic-job-lite</module>
         <module>elastic-job-cloud</module>
+        <module>elastic-job-example</module>
     </modules>
     
     <properties>


### PR DESCRIPTION
当任务分片到集群中各节点执行的时候，提高了吞吐量，相比于之前的单点失去数据顺序的功能，比如任务的执行需要全局顺序，局部无序（比如把任务分为6片，6个节点执行，每片根据时间排序抓取前100条记录，必须等这6片全部执行完后，此任务才能下一次触发，这就是全局顺序，但是这6个节点并行执行，却不要求顺序，就是局部无序），那么目前就做不到了，因为每个节点执行任务的不确定性，有可能某个节点还没执行完，此任务的第二次触发就开始了，有可能后面抓取的数据在前一批处理完。
所以我提了这个PR，保证任务的全局顺序，我感觉这应该是一个比较多的业务场景


另外的一个PR，就是支持分片策略类从spring容器中加载，而不是只能通过newInstance的方式去初始化