### PR TITLE
fix misfire task is executed more than expected case

### DIFF
--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/schedule/JobTriggerListener.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/schedule/JobTriggerListener.java
@@ -44,6 +44,6 @@ public final class JobTriggerListener extends TriggerListenerSupport {
     
     @Override
     public void triggerMisfired(final Trigger trigger) {
-        executionService.setMisfire(shardingService.getLocalHostShardingItems());
+//        executionService.setMisfire(shardingService.getLocalHostShardingItems());
     }
 }


### PR DESCRIPTION
quartz本身已经做了misfire不需要重复触发misfire任务了，abstractelasticjobexecutor里面正常执行完任务后已经可以了，再次判断misfire等于把misfire任务执行了2次