### PR TITLE
修改html和js中接口的url为相对路径

### DIFF
--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/app/app_common.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/app/app_common.js
@@ -26,7 +26,7 @@ function validate() {
                             var appName = $("#app-name").val();
                             var result = true;
                                 $.ajax({
-                                    url: "/api/app/" + appName,
+                                    url: "api/app/" + appName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function(data) {
@@ -92,7 +92,7 @@ function submitConfirm(type, modal) {
                 type: type,
                 dataType: "json",
                 data: JSON.stringify(getApp()),
-                url: "/api/app",
+                url: "api/app",
                 contentType: "application/json",
                 success: function(data) {
                     modal.modal("hide");

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/app/apps_overview.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/app/apps_overview.js
@@ -15,7 +15,7 @@ $(function() {
 
 function renderAppOverview() {
     var jsonData = {
-        url: "/api/app/list",
+        url: "api/app/list",
         cache: false,
         columns:
             [{
@@ -63,7 +63,7 @@ function bindDetailAppButton() {
     $(document).on("click", "button[operation='detailApp'][data-toggle!='modal']", function(event) {
         var appName = $(event.currentTarget).attr("appName");
         $.ajax({
-            url: "/api/app/" + appName,
+            url: "api/app/" + appName,
             contentType: "application/json",
             success: function(result) {
                 if (null !== result) {
@@ -86,7 +86,7 @@ function bindModifyAppButton() {
     $(document).on("click", "button[operation='modifyApp'][data-toggle!='modal']", function(event) {
         var appName = $(event.currentTarget).attr("appName");
         $.ajax({
-            url: "/api/app/" + appName,
+            url: "api/app/" + appName,
             success: function(result) {
                 if(null !== result) {
                     $(".box-body").remove();
@@ -105,7 +105,7 @@ function bindEnableAppButton() {
     $(document).on("click", "button[operation='enableApp'][data-toggle!='modal']", function(event) {
         var appName = $(event.currentTarget).attr("appName");
         $.ajax({
-            url: "/api/app/" + appName + "/disable",
+            url: "api/app/" + appName + "/disable",
             type: "DELETE",
             contentType: "application/json",
             success: function(result) {
@@ -121,7 +121,7 @@ function bindDisableAppButton() {
     $(document).on("click", "button[operation='disableApp'][data-toggle!='modal']", function(event) {
         var appName = $(event.currentTarget).attr("appName");
         $.ajax({
-            url: "/api/app/" + appName + "/disable",
+            url: "api/app/" + appName + "/disable",
             type: "POST",
             contentType: "application/json",
             success: function(result) {
@@ -144,7 +144,7 @@ function bindDeleteAppButton() {
         $("#delete-app-confirm").on("click", function() {
             if(flag) {
                 $.ajax({
-                    url: "/api/app/" + appName,
+                    url: "api/app/" + appName,
                     type: "DELETE",
                     contentType: "application/json",
                     success: function(result) {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/common/common.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/common/common.js
@@ -15,7 +15,7 @@ function showFailDialog() {
 
 function refreshJobNavTag() {
     $.ajax({
-        url: "/api/job/jobs",
+        url: "api/job/jobs",
         cache: false,
         success: function(data) {
             $("#job-nav-tag").text(data.length);
@@ -25,7 +25,7 @@ function refreshJobNavTag() {
 
 function refreshAppNavTag() {
     $.ajax({
-        url: "/api/app/list",
+        url: "api/app/list",
         cache: false,
         success: function(data) {
             $("#app-nav-tag").text(data.length);
@@ -74,7 +74,7 @@ function selectAppStatus(appName) {
     $.ajax({
         type: "GET",
         async: false,
-        url: "/api/app/" + appName + "/disable",
+        url: "api/app/" + appName + "/disable",
         contentType: "application/json",
         success: function(result) {
             resultValue = result;
@@ -86,7 +86,7 @@ function selectAppStatus(appName) {
 function authorityControl() {
     $.ajax({
         type: "HEAD",
-        url : "/",
+        url : "",
         complete: function(xhr, data) {
             if ("guest" === xhr.getResponseHeader("identify")) {
                 $("table").on("all.bs.table", function() {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/common/job_edit_base.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/common/job_edit_base.js
@@ -48,7 +48,7 @@ function bootstrapValidator(){
                             var jobName = $('#jobName').val();
                             var res = true;
                                 $.ajax({
-                                    url: '/api/job/jobs/'+jobName,
+                                    url: 'api/job/jobs/'+jobName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function (data) {
@@ -81,7 +81,7 @@ function bootstrapValidator(){
                             var appName = $('#appName').val();
                             var res = true;
                                 $.ajax({
-                                    url: '/api/app/'+appName,
+                                    url: 'api/app/'+appName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function (data) {
@@ -103,7 +103,7 @@ function bootstrapValidator(){
                             var appName = $('#jobAppName').val();
                             var res = false;
                                 $.ajax({
-                                    url: '/api/app/'+appName,
+                                    url: 'api/app/'+appName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function (data) {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/history/job_dashboard.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/history/job_dashboard.js
@@ -11,7 +11,7 @@ $(function() {
 
 function renderPieChartSinceLastMinuteData() {
     $.ajax({
-        url: "/api/job/statistics/tasks/results/lastMinute",
+        url: "api/job/statistics/tasks/results/lastMinute",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -26,7 +26,7 @@ function renderPieChartSinceLastMinuteData() {
 
 function renderPieChartSinceLastHourData() {
     $.ajax({
-        url: "/api/job/statistics/tasks/results/lastHour",
+        url: "api/job/statistics/tasks/results/lastHour",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -41,7 +41,7 @@ function renderPieChartSinceLastHourData() {
 
 function renderPieChartSinceLastWeekData() {
     $.ajax({
-        url: "/api/job/statistics/tasks/results/lastWeek",
+        url: "api/job/statistics/tasks/results/lastWeek",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -56,7 +56,7 @@ function renderPieChartSinceLastWeekData() {
 
 function renderJobTypePieChart() {
     $.ajax({
-        url: "/api/job/statistics/jobs/type",
+        url: "api/job/statistics/jobs/type",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -71,7 +71,7 @@ function renderJobTypePieChart() {
 
 function renderJobExecutionTypePieChart() {
     $.ajax({
-        url: "/api/job/statistics/jobs/executionType",
+        url: "api/job/statistics/jobs/executionType",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -86,7 +86,7 @@ function renderJobExecutionTypePieChart() {
 
 function renderStasticsJobsLineChart() {
     $.ajax({
-        url: "/api/job/statistics/tasks/results?since=last24hours",
+        url: "api/job/statistics/tasks/results?since=last24hours",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {
@@ -107,11 +107,11 @@ function renderStasticsJobsLineChart() {
 
 function renderRunningJobsAndTasksLineChart() {
     $.ajax({
-        url: "/api/job/statistics/jobs/running?since=lastWeek",
+        url: "api/job/statistics/jobs/running?since=lastWeek",
         dataType: "json",
         success: function(jobData) {
             $.ajax({
-                url: "/api/job/statistics/tasks/running?since=lastWeek",
+                url: "api/job/statistics/tasks/running?since=lastWeek",
                 dataType: "json",
                 success: function(taskData) {
                     if(null !== taskData) {
@@ -137,7 +137,7 @@ function renderRunningJobsAndTasksLineChart() {
 
 function renderRegisteredJobs() {
     $.ajax({
-        url: "/api/job/statistics/jobs/register",
+        url: "api/job/statistics/jobs/register",
         dataType: "json",
         success: function(jobData) {
             if(null !== jobData) {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/add_job.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/add_job.js
@@ -1,5 +1,5 @@
 $(function() {
     validate();
     dataControl();
-    submitConfirm("post", "/api/job/register", $("#data-add-job"));
+    submitConfirm("post", "api/job/register", $("#data-add-job"));
 });

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/job_common.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/job_common.js
@@ -38,7 +38,7 @@ function validate() {
                             var jobName = $("#job-name").val();
                             var result = true;
                                 $.ajax({
-                                    url: "/api/job/jobs/" + jobName,
+                                    url: "api/job/jobs/" + jobName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function(data) {
@@ -60,7 +60,7 @@ function validate() {
                             var appName = $("#job-app-name").val();
                             var result = false;
                                 $.ajax({
-                                    url: "/api/app/" + appName,
+                                    url: "api/app/" + appName,
                                     contentType: "application/json",
                                     async: false,
                                     success: function(data) {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/jobs_overview.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/jobs_overview.js
@@ -15,7 +15,7 @@ $(function() {
 
 function renderJobOverview() {
     var jsonData = {
-        url: "/api/job/jobs",
+        url: "api/job/jobs",
         cache: false,
         columns:
             [{
@@ -71,7 +71,7 @@ function selectJobStatus(jobName) {
     $.ajax({
         type:"GET",
         async: false,
-        url: "/api/job/" + jobName + "/disable",
+        url: "api/job/" + jobName + "/disable",
         contentType: "application/json",
         success: function(result) {
             resultValue = result;
@@ -85,7 +85,7 @@ function bindDetailJobButton() {
     $(document).on("click", "button[operation='detailJob'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("jobName");
         $.ajax({
-            url: "/api/job/jobs/" + jobName,
+            url: "api/job/jobs/" + jobName,
             contentType: "application/json",
             success: function(result) {
                 $(".box-body").remove();
@@ -118,7 +118,7 @@ function bindDeleteJobButton() {
         $("#delete-job-confirm").on("click", function() {
             if(flag) {
                 $.ajax({
-                    url: "/api/job/deregister",
+                    url: "api/job/deregister",
                     type: "DELETE",
                     contentType: "application/json",
                     data: jobName,
@@ -138,7 +138,7 @@ function bindModifyJobButton() {
     $(document).on("click", "button[operation='modifyJob'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("jobName");
         $.ajax({
-            url: "/api/job/jobs/" + jobName,
+            url: "api/job/jobs/" + jobName,
             success: function(result) {
                 if (null !== result) {
                     $(".box-body").remove();
@@ -161,7 +161,7 @@ function bindEnableJobButton() {
             showFailDialog();
         } else {
             $.ajax({
-                url: "/api/job/" + jobName + "/disable",
+                url: "api/job/" + jobName + "/disable",
                 type: "DELETE",
                 contentType: "application/json",
                 success: function(result) {
@@ -178,7 +178,7 @@ function bindDisableJobButton() {
     $(document).on("click", "button[operation='disableJob'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("jobName");
         $.ajax({
-            url: "/api/job/" + jobName + "/disable",
+            url: "api/job/" + jobName + "/disable",
             type: "POST",
             contentType: "application/json",
             success: function(result) {

--- a/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/modify_job.js
+++ b/elastic-job-cloud/elastic-job-cloud-scheduler/src/main/resources/console/js/job/modify_job.js
@@ -1,5 +1,5 @@
 $(function() {
     validate();
     dataControl();
-    submitConfirm("put", "/api/job/update", $("#data-update-job"));
+    submitConfirm("put", "api/job/update", $("#data-update-job"));
 });

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/html/history/job_event_trace_history.html
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/html/history/job_event_trace_history.html
@@ -39,7 +39,7 @@
             data-show-toggle="true"
             data-striped="true"
             data-toggle="table"
-            data-url="/api/event-trace/execution"
+            data-url="api/event-trace/execution"
             data-flat="true"
             data-click-to-select="true"
             data-row-style="rowStyle"

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/html/history/job_status_history.html
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/html/history/job_status_history.html
@@ -41,7 +41,7 @@
                data-show-toggle="true"
                data-striped="true"
                data-toggle="table"
-               data-url="/api/event-trace/status"
+               data-url="api/event-trace/status"
                data-flat="true"
                data-click-to-select="true"
                data-row-style="rowStyle"

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/job_config.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/job_config.js
@@ -7,7 +7,7 @@ function getJobParams() {
     var jobName = $("#job-overviews-name").text();
     var jobParams;
     $.ajax({
-        url: "/api/jobs/config/" + jobName,
+        url: "api/jobs/config/" + jobName,
         async: false,
         success: function(data) {
             jobParams = data;
@@ -63,7 +63,7 @@ function bindSubmitJobSettingsForm() {
 
 function submitAjax(postJson) {
     $.ajax({
-        url: "/api/jobs/config",
+        url: "api/jobs/config",
         type: "PUT",
         data: JSON.stringify(postJson),
         contentType: "application/json",

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/job_status_detail.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/job_status_detail.js
@@ -9,7 +9,7 @@ $(function() {
 function renderShardingTable() {
     var jobName = $("#job-name").text();
     $("#sharding").bootstrapTable({
-        url: "/api/jobs/" + jobName + "/sharding",
+        url: "api/jobs/" + jobName + "/sharding",
         cache: false,
         columns: [
             {
@@ -82,7 +82,7 @@ function bindDisableButton() {
         var jobName = $("#index-job-name").text();
         var item = $(event.currentTarget).attr("item");
         $.ajax({
-            url: "/api/jobs/" + jobName + "/sharding/" + item + "/disable",
+            url: "api/jobs/" + jobName + "/sharding/" + item + "/disable",
             type: "POST",
             success: function() {
                 showSuccessDialog();
@@ -98,7 +98,7 @@ function bindEnableButton() {
         var jobName = $("#index-job-name").text();
         var item = $(event.currentTarget).attr("item");
         $.ajax({
-            url: "/api/jobs/" + jobName + "/sharding/" + item + "/disable",
+            url: "api/jobs/" + jobName + "/sharding/" + item + "/disable",
             type: "DELETE",
             success: function () {
                 showSuccessDialog();

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/jobs_status_overview.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/job/jobs_status_overview.js
@@ -37,14 +37,14 @@ function renderJobsOverview() {
     };
     var activated = false;
     $.ajax({
-        url: "/api/registry-center/activated",
+        url: "api/registry-center/activated",
         async: false,
         success: function(data) {
             activated = data;
         }
     });
     if (activated) {
-        jsonData.url = "/api/jobs";
+        jsonData.url = "api/jobs";
     }
     $("#jobs-status-overview-tbl").bootstrapTable({
         columns: jsonData.columns,
@@ -109,7 +109,7 @@ function bindModifyButton() {
     $(document).on("click", "button[operation='modify-job'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("job-name");
         $.ajax({
-            url: "/api/jobs/config/" + jobName,
+            url: "api/jobs/config/" + jobName,
             success: function(data) {
                 if (null !== data) {
                     $(".box-body").remove();
@@ -138,7 +138,7 @@ function bindTriggerButton() {
     $(document).on("click", "button[operation='trigger-job'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("job-name");
         $.ajax({
-            url: "/api/jobs/" + jobName + "/trigger",
+            url: "api/jobs/" + jobName + "/trigger",
             type: "POST",
             success: function() {
                 showSuccessDialog();
@@ -153,7 +153,7 @@ function bindDisableButton() {
     $(document).on("click", "button[operation='disable-job'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("job-name");
         $.ajax({
-            url: "/api/jobs/" + jobName + "/disable",
+            url: "api/jobs/" + jobName + "/disable",
             type: "POST",
             success: function() {
                 showSuccessDialog();
@@ -168,7 +168,7 @@ function bindEnableButton() {
     $(document).on("click", "button[operation='enable-job'][data-toggle!='modal']", function(event) {
         var jobName = $(event.currentTarget).attr("job-name");
         $.ajax({
-            url: "/api/jobs/" + jobName + "/disable",
+            url: "api/jobs/" + jobName + "/disable",
             type: "DELETE",
             success: function() {
                 showSuccessDialog();
@@ -186,7 +186,7 @@ function bindShutdownButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/jobs/" + jobName + "/shutdown",
+                url: "api/jobs/" + jobName + "/shutdown",
                 type: "POST",
                 success: function () {
                     $("#confirm-dialog").modal("hide");
@@ -207,7 +207,7 @@ function bindRemoveButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/jobs/config/" + jobName,
+                url: "api/jobs/config/" + jobName,
                 type: "DELETE",
                 success: function() {
                     $("#confirm-dialog").modal("hide");

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/server/server_status_detail.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/server/server_status_detail.js
@@ -9,7 +9,7 @@ $(function() {
 function renderJobs() {
     var ip = $("#server-ip").text();
     $("#server-jobs-tbl").bootstrapTable({
-        url: "/api/servers/" + ip + "/jobs",
+        url: "api/servers/" + ip + "/jobs",
         cache: false,
         columns: 
         [{
@@ -73,7 +73,7 @@ function bindDisableButton() {
     $(document).off("click", "button[operation='disable-server-job'][data-toggle!='modal']");
     $(document).on("click", "button[operation='disable-server-job'][data-toggle!='modal']", function(event) {
         $.ajax({
-            url: "/api/servers/" + $("#server-ip").text() + "/jobs/" + $(event.currentTarget).attr("job-name") + "/disable",
+            url: "api/servers/" + $("#server-ip").text() + "/jobs/" + $(event.currentTarget).attr("job-name") + "/disable",
             type: "POST",
             success: function() {
                 $("#server-jobs-tbl").bootstrapTable("refresh");
@@ -87,7 +87,7 @@ function bindEnableButton() {
     $(document).off("click", "button[operation='enable-server-job'][data-toggle!='modal']");
     $(document).on("click", "button[operation='enable-server-job'][data-toggle!='modal']", function(event) {
         $.ajax({
-            url: "/api/servers/" + $("#server-ip").text() + "/jobs/" + $(event.currentTarget).attr("job-name") + "/disable",
+            url: "api/servers/" + $("#server-ip").text() + "/jobs/" + $(event.currentTarget).attr("job-name") + "/disable",
             type: "DELETE",
             success: function() {
                 $("#server-jobs-tbl").bootstrapTable("refresh");
@@ -106,7 +106,7 @@ function bindShutdownButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/servers/" + serverIp + "/jobs/" + jobName + "/shutdown",
+                url: "api/servers/" + serverIp + "/jobs/" + jobName + "/shutdown",
                 type: "POST",
                 success: function () {
                     $("#confirm-dialog").modal("hide");
@@ -128,7 +128,7 @@ function bindRemoveButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/servers/" + serverIp + "/jobs/" + jobName,
+                url: "api/servers/" + serverIp + "/jobs/" + jobName,
                 type: "DELETE",
                 success: function () {
                     $("#confirm-dialog").modal("hide");

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/server/servers_status_overview.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/status/server/servers_status_overview.js
@@ -32,14 +32,14 @@ function renderServersOverview() {
     };
     var activated = false;
     $.ajax({
-        url: "/api/registry-center/activated",
+        url: "api/registry-center/activated",
         async: false,
         success: function(data) {
             activated = data;
         }
     });
     if (activated) {
-        jsonData.url = "/api/servers";
+        jsonData.url = "api/servers";
     }
     $("#servers-overview-tbl").bootstrapTable({
         columns: jsonData.columns,
@@ -88,7 +88,7 @@ function bindDisableServerButton() {
     $(document).on("click", "button[operation='disable-server'][data-toggle!='modal']", function(event) {
         var serverIp = $(event.currentTarget).attr("server-ip");
         $.ajax({
-            url: "/api/servers/" + serverIp + "/disable",
+            url: "api/servers/" + serverIp + "/disable",
             type: "POST",
             success: function() {
                 showSuccessDialog();
@@ -103,7 +103,7 @@ function bindEnableServerButton() {
     $(document).on("click", "button[operation='enable-server'][data-toggle!='modal']", function(event) {
         var serverIp = $(event.currentTarget).attr("server-ip");
         $.ajax({
-            url: "/api/servers/" + serverIp + "/disable",
+            url: "api/servers/" + serverIp + "/disable",
             type: "DELETE",
             success: function() {
                 showSuccessDialog();
@@ -121,7 +121,7 @@ function bindShutdownServerButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/servers/" + serverIp + "/shutdown",
+                url: "api/servers/" + serverIp + "/shutdown",
                 type: "POST",
                 success: function () {
                     $("#confirm-dialog").modal("hide");
@@ -142,7 +142,7 @@ function bindRemoveServerButton() {
         $(document).off("click", "#confirm-btn");
         $(document).on("click", "#confirm-btn", function() {
             $.ajax({
-                url: "/api/servers/" + serverIp,
+                url: "api/servers/" + serverIp,
                 type: "DELETE",
                 success: function () {
                     $("#confirm-dialog").modal("hide");

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/util/common.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/util/common.js
@@ -25,7 +25,7 @@ function showFailureDialog(msg) {
 function authorityControl() {
     $.ajax({
         type: "HEAD",
-        url : "/",
+        url : "",
         complete: function(xhr, data) {
             if ("guest" === xhr.getResponseHeader("identify")) {
                 $("table").on("all.bs.table", function() {

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/util/dashboard.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/util/dashboard.js
@@ -211,7 +211,7 @@ function refreshEventTraceNavTag() {
 
 function refreshJobNavTag() {
     $.ajax({
-        url: "/api/jobs/count",
+        url: "api/jobs/count",
         cache: false,
         success: function(data) {
             $("#job-nav-tag").text(data);
@@ -221,7 +221,7 @@ function refreshJobNavTag() {
 
 function refreshServerNavTag() {
     $.ajax({
-        url: "/api/servers/count",
+        url: "api/servers/count",
         cache: false,
         success: function(data) {
             $("#server-nav-tag").text(data);


### PR DESCRIPTION
1、调整被访问接口的url为相对路径，例如：将/api/jobs/count，改为api/jobs/count。目的是便于为应用增加context，例如：通过http://127.0.0.1:8899/ejlc进行访问，也便于nginx进行负载。代码中有大约50%的接口的url为相对路径，只是将剩余的50%也修改为了相对路径。

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
