### PR TITLE
解决历史轨迹和历史状态查看失败原因看不了的问题

### DIFF
--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/history/job_event_trace_history.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/history/job_event_trace_history.js
@@ -43,7 +43,8 @@ function splitFormatter(value) {
     var replacement = "...";
     if(null != value && value.length > maxLength) {
         var vauleDetail = value.substring(0 , maxLength - replacement.length) + replacement;
-        return '<a href="javascript: void(0);" style="color:#FF0000;" onClick="showHistoryMessage(\'' + value.replace(/\n/g,"<br/>") + '\')">' + vauleDetail + '</a>';
+        value = value.replace(/\n/g,"<br/>").replace(/\'/g, "\\'").replace(/\r/g,"<br/>");
+        return '<a href="javascript: void(0);" style="color:#FF0000;" onClick="showHistoryMessage(\'' + value + '\')">' + vauleDetail + '</a>';
     }
     return value;
 }

--- a/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/history/job_status_history.js
+++ b/elastic-job-lite/elastic-job-lite-console/src/main/resources/console/js/history/job_status_history.js
@@ -29,7 +29,7 @@ function splitRemarkFormatter(value, row) {
     var replacement = "...";
     if(null != value && value.length > maxLength) {
         var valueDetail = value.substring(0 , maxLength - replacement.length) + replacement;
-        value = value.replace(/\n/g,"<br/>").replace(/\'/g, "\\'");
+        value = value.replace(/\n/g,"<br/>").replace(/\'/g, "\\'").replace(/\r/g,"<br/>");
         var remarkHtml;
         if ("TASK_FAILED" === row.state || "TASK_ERROR" === row.state) {
             remarkHtml = '<a href="javascript: void(0);" style="color:#FF0000;" onClick="showHistoryMessage(\'' + value + '\')">' + valueDetail + '</a>';


### PR DESCRIPTION
Fixes #291 .

错误日志换行没有替换干净,导致js报错,看不了详情(window下的"\r"没有替换)
