### PR TITLE
waitingOtherJobCompleted重命名为waitingOtherShardingItemCompleted

### DIFF
--- a/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/sharding/ShardingService.java
+++ b/elastic-job-lite/elastic-job-lite-core/src/main/java/com/dangdang/ddframe/job/lite/internal/sharding/ShardingService.java
@@ -108,7 +108,7 @@ public final class ShardingService {
             blockUntilShardingCompleted();
             return;
         }
-        waitingOtherJobCompleted();
+        waitingOtherShardingItemCompleted();
         LiteJobConfiguration liteJobConfig = configService.load(false);
         int shardingTotalCount = liteJobConfig.getTypeConfig().getCoreConfig().getShardingTotalCount();
         log.debug("Job '{}' sharding begin.", jobName);
@@ -126,7 +126,7 @@ public final class ShardingService {
         }
     }
     
-    private void waitingOtherJobCompleted() {
+    private void waitingOtherShardingItemCompleted() {
         while (executionService.hasRunningItems()) {
             log.debug("Job '{}' sleep short time until other job completed.", jobName);
             BlockUtils.waitingShortTime();


### PR DESCRIPTION
建议把ShardingService类中私有方法waitingOtherJobCompleted重命名为waitingOtherShardingItemCompleted